### PR TITLE
fix(editable-commands): register post initialization instead of pre-

### DIFF
--- a/packages/editable-commands/src/register.ts
+++ b/packages/editable-commands/src/register.ts
@@ -1,4 +1,4 @@
-import { Plugin, preInitialization, SapphireClient } from '@sapphire/framework';
+import { Plugin, postInitialization, SapphireClient } from '@sapphire/framework';
 import { join } from 'path';
 
 /**
@@ -8,9 +8,9 @@ export class EditableCommandsPlugin extends Plugin {
 	/**
 	 * @since 1.0.0
 	 */
-	public static [preInitialization](this: SapphireClient): void {
+	public static [postInitialization](this: SapphireClient): void {
 		this.stores.get('listeners').registerPath(join(__dirname, 'listeners'));
 	}
 }
 
-SapphireClient.plugins.registerPreInitializationHook(EditableCommandsPlugin[preInitialization], 'EditableCommands-PreInitialization');
+SapphireClient.plugins.registerPostInitializationHook(EditableCommandsPlugin[postInitialization], 'EditableCommands-PostInitialization');


### PR DESCRIPTION
Whenever running this plugin, I get the error:
```
C:\Users\xxx\OneDrive\Desktop\xxx\node_modules\@sapphire\plugin-editable-commands\dist\register.js:14
        this.stores.get('listeners').registerPath(path_1.join(__dirname, 'listeners'));
                                    ^

TypeError: Cannot read property 'registerPath' of undefined
    at SapphireClient.[SapphireFrameworkPluginsPreInitialization] (C:\Users\xxx\OneDrive\Desktop\xxx\node_modules\@sapphire\plugin-editable-commands\dist\register.js:14:37)
    at new SapphireClient (C:\Users\xxx\OneDrive\Desktop\xxx\node_modules\@sapphire\framework\dist\lib\SapphireClient.js:83:25)
```

I believe this is because the `preInitialization` hook is triggered before the listener store (and all other stores) are registered. Quickly changing it to `post*` fixed the problem for me.