### PR TITLE
[@sapphire/plugin-i18next] Fixed loading of languages that do not use hyphens

### DIFF
--- a/packages/i18next/src/lib/InternationalizationHandler.ts
+++ b/packages/i18next/src/lib/InternationalizationHandler.ts
@@ -189,13 +189,14 @@ export class InternationalizationHandler {
 	public async walkLanguageDirectory(dir: string, namespaces: string[] = [], current = '') {
 		const directory = await opendir(dir);
 
+		const availableLanguages: string[] = ['en-US', 'en-GB', 'zh-CN', 'zh-TW', 'cs', 'da', 'nl', 'fr', 'de', 'el', 'hu', 'it', 'ja', 'ko', 'no', 'pl', 'pt-BR', 'ru', 'es-ES', 'sv-SE', 'tr', 'bg', 'uk', 'fi', 'hr', 'ro', 'lt'];
 		const languages: string[] = [];
 		for await (const entry of directory) {
 			const fn = entry.name;
 			if (entry.isDirectory()) {
 				// This structure may very well be changed in future.
 				// See i18next/i18next-fs-backend#13
-				const isLanguage = fn.includes('-');
+				const isLanguage = availableLanguages.includes(fn);
 				if (isLanguage) languages.push(fn);
 
 				({ namespaces } = await this.walkLanguageDirectory(join(dir, fn), namespaces, isLanguage ? '' : `${fn}/`));


### PR DESCRIPTION
# Summary
When using the i18next plugin, even though I inserted "ja(Japanese)" in the language directory, it was not actually loaded and the following error occurred.
```bash
2021-09-18 21:53:34 - ERROR - Encountered error on command "example" at path "/src/commands/General/help.js" ReferenceError: Invalid language provided
2021-09-18 21:53:34 - ERROR -     at InternationalizationHandler.format (/node_modules/@sapphire/plugin-i18next/dist/lib/InternationalizationHandler.js:194:19)
2021-09-18 21:53:34 - ERROR -     at Object.resolveKey (/node_modules/@sapphire/plugin-i18next/dist/lib/functions.js:52:36)
2021-09-18 21:53:34 - ERROR -     at processTicksAndRejections (node:internal/process/task_queues:96:5)
2021-09-18 21:53:34 - ERROR -     at async HelpCommand.run (/src/commands/General/help.js:28:29)
2021-09-18 21:53:34 - ERROR -     at async CoreListener.run (/node_modules/@sapphire/framework/dist/listeners/command-handler/CoreCommandAccepted.js:15:28)
2021-09-18 21:53:34 - ERROR -     at async CoreListener._run (/node_modules/@sapphire/framework/dist/lib/structures/Listener.js:92:13)
```
The directory structure is as follows.
```bash
/
    src
        commands
            General
                example.js
        languages
            en-US
            ja
        main.js
    package.json
    package-lock.json
```
So I traced the error and found out that the function "walkLanguageDirectory" has a variable "isLanguage" which is the result of judging whether the language directory is a language directory or not, based on whether the language directory has a hyphen or not.
```js
// This structure may very well be changed in future.
// See i18next/i18next-fs-backend#13
const isLanguage = fn.includes('-');
if (isLanguage) languages.push(fn);
```
So I made a list of the languages available in the existing Discord and edited the array to add a language if it matches the directory.
The following is the code that picks up the changes.
```js
const availableLanguages: string[] = ['en-US', 'en-GB', 'zh-CN', 'zh-TW', 'cs', 'da', 'nl', 'fr', 'de', 'el', 'hu', 'it', 'ja', 'ko', 'no', 'pl', 'pt-BR', 'ru', 'es-ES', 'sv-SE', 'tr', 'bg', 'uk', 'fi', 'hr', 'ro', 'lt'];

const isLanguage = availableLanguages.includes(fn);
```
For a list of languages, see the following website.
https://discord.com/developers/docs/dispatch/field-values#predefined-field-values-accepted-locales