### PR TITLE
feat(plugin-i18n): add new syntax for formatters in i18next

### DIFF
--- a/packages/i18next/src/lib/InternationalizationHandler.ts
+++ b/packages/i18next/src/lib/InternationalizationHandler.ts
@@ -141,6 +141,11 @@ export class InternationalizationHandler {
 			this.languages.set(item, i18next.getFixedT(item));
 		}
 		this.languagesLoaded = true;
+
+		const formatters = this.options.formatters ?? [];
+		for (const { name, format } of formatters) {
+			i18next.services.formatter!.add(name, format);
+		}
 	}
 
 	/**

--- a/packages/i18next/src/lib/types.ts
+++ b/packages/i18next/src/lib/types.ts
@@ -54,6 +54,15 @@ export interface InternationalizationOptions {
 	 * @since 1.0.0
 	 */
 	defaultNS?: string;
+
+	/**
+	 * Array of formatters to add to i18n.
+	 *
+	 * @since 2.0.0
+	 * @default []
+	 */
+	formatters?: I18nextFormatters[];
+
 	/**
 	 * A function that is to be used to retrieve the language for the current context.
 	 * Context exists of a {@link Guild `guild`}, a {@link DiscordChannel `channel`} and a {@link User `user`}.
@@ -82,4 +91,9 @@ export interface InternationalizationContext {
 
 export interface InternationalizationClientOptions {
 	i18n?: InternationalizationOptions;
+}
+
+export interface I18nextFormatters {
+	name: string;
+	format(value: any, lng: string | undefined, options: any): string;
 }


### PR DESCRIPTION
This PR adds an option to the `InternationalizationOptions` called `formatters` which takes in a `I18nextFormatters` array to add to i18n via the `i18next.services.formatter.add` syntax, as described in https://www.i18next.com/translation-function/formatting#basic-usage.

Goal here is to move off the old, deprecated syntax and move to the new syntax, as the old way of adding formatters is considered deprecated in i18n version 21, described in https://www.i18next.com/translation-function/formatting#legacy-format-function-i18next-less-than-21.3.0.