### PR TITLE
feat(scheduled-tasks): expose the strategy client as getter

### DIFF
--- a/packages/scheduled-tasks/src/index.ts
+++ b/packages/scheduled-tasks/src/index.ts
@@ -3,6 +3,13 @@ import type { ScheduledTaskStore } from './lib/structures/ScheduledTaskStore';
 import type { ScheduledTasksOptions } from './lib/types/ScheduledTasksOptions';
 
 export * from './lib/ScheduledTaskHandler';
+export type {
+	Client as BullClient,
+	ScheduledTaskRedisStrategy,
+	ScheduledTaskRedisStrategyJob,
+	ScheduledTaskRedisStrategyOptions
+} from './lib/strategies/ScheduledTaskRedisStrategy';
+export type { Client as SQSClient, ScheduledTaskSQSStrategy, ScheduledTaskSQSStrategyMessageBody } from './lib/strategies/ScheduledTaskSQSStrategy';
 export * from './lib/structures/ScheduledTask';
 export * from './lib/structures/ScheduledTaskStore';
 export * from './lib/types';

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -14,11 +14,13 @@ export interface ScheduledTaskRedisStrategyJob {
 	payload?: unknown;
 }
 
-export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy<Queue<ScheduledTaskRedisStrategyJob>> {
+export type Client = Queue<ScheduledTaskRedisStrategyJob>;
+
+export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy<Client> {
 	public readonly options: QueueOptions;
 	public readonly queue: string;
 
-	private bullClient!: Queue<ScheduledTaskRedisStrategyJob>;
+	private bullClient!: Client;
 
 	public constructor(options?: ScheduledTaskRedisStrategyOptions) {
 		this.queue = options?.queue ?? 'scheduled-tasks';

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
@@ -15,7 +15,7 @@ export interface ScheduledTaskSQSStrategyMessageBody {
 export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy<Producer> {
 	public readonly options: ConsumerOptions;
 
-	public producer: Producer;
+	private producer: Producer;
 
 	public constructor(options: ConsumerOptions) {
 		this.options = options;

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
@@ -12,6 +12,8 @@ export interface ScheduledTaskSQSStrategyMessageBody {
 	options: ScheduledTasksTaskOptions;
 }
 
+export type Client = Producer;
+
 export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy<Producer> {
 	public readonly options: ConsumerOptions;
 

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
@@ -1,6 +1,6 @@
 import { container, from, isErr } from '@sapphire/framework';
 import { randomBytes } from 'crypto';
-import { Consumer, ConsumerOptions } from 'sqs-consumer';
+import { Consumer, type ConsumerOptions } from 'sqs-consumer';
 import { Producer } from 'sqs-producer';
 import type { ScheduledTaskCreateRepeatedTask, ScheduledTasksTaskOptions } from '../types';
 import type { ScheduledTaskBaseStrategy } from '../types/ScheduledTaskBaseStrategy';
@@ -12,14 +12,18 @@ export interface ScheduledTaskSQSStrategyMessageBody {
 	options: ScheduledTasksTaskOptions;
 }
 
-export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy {
+export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy<Producer> {
 	public readonly options: ConsumerOptions;
 
-	private producer: Producer;
+	public producer: Producer;
 
 	public constructor(options: ConsumerOptions) {
 		this.options = options;
 		this.producer = Producer.create(this.options);
+	}
+
+	public get client() {
+		return this.producer;
 	}
 
 	public connect() {

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTaskBaseStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTaskBaseStrategy.ts
@@ -2,7 +2,8 @@ import type { Awaitable } from '@sapphire/utilities';
 import type { ScheduledTaskCreateRepeatedTask } from './ScheduledTaskCreateRepeatedTask';
 import type { ScheduledTasksTaskOptions } from './ScheduledTasksTaskOptions';
 
-export interface ScheduledTaskBaseStrategy {
+export interface ScheduledTaskBaseStrategy<T = unknown> {
+	client: T;
 	connect(): void;
 	create(task: string, payload: unknown, options?: ScheduledTasksTaskOptions): void;
 	createRepeated(tasks: ScheduledTaskCreateRepeatedTask[]): void;

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTasksOptions.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTasksOptions.ts
@@ -1,4 +1,4 @@
-import type { ScheduledTaskBaseStrategy } from '.';
+import type { ScheduledTaskBaseStrategy } from './ScheduledTaskBaseStrategy';
 
 export interface ScheduledTasksOptions {
 	strategy: ScheduledTaskBaseStrategy;


### PR DESCRIPTION
This is an easy way to get at the original client of the strategy.

I have opted to not expose it on the `ScheduledTaskHandler` level
because that would mean the handler would need the types
for both SQS and Bull which is what we want to avoid.
