### PR TITLE
fix(pattern-commands): resolve listener triggering twice in rare cases

### DIFF
--- a/packages/pattern-commands/src/index.ts
+++ b/packages/pattern-commands/src/index.ts
@@ -4,7 +4,9 @@ export * from './lib/structures/PaternCommandStore';
 export * from './lib/structures/PatternCommand';
 export * from './lib/utils/PaternCommandEvents';
 export * from './lib/utils/PatternCommandInterfaces';
-export * as PatternCommandListeners from './listeners';
+export { CommandAcceptedListener as PluginPatternCommandsCommandAcceptedListener } from './listeners/PluginCommandAccepted';
+export { MessageParseListener as PluginPatternCommandsMessageParseListener } from './listeners/PluginMessageParse';
+export { PreCommandRunListener as PluginPatternCommandsPreCommandRunListener } from './listeners/PluginPreCommandRun';
 
 declare module '@sapphire/pieces' {
 	interface StoreRegistryEntries {

--- a/packages/pattern-commands/src/listeners/index.ts
+++ b/packages/pattern-commands/src/listeners/index.ts
@@ -1,3 +1,0 @@
-export { CommandAcceptedListener as PluginPatternCommandsCommandAcceptedListener } from './PluginCommandAccepted';
-export { MessageParseListener as PluginPatternCommandsMessageParseListener } from './PluginMessageParse';
-export { PreCommandRunListener as PluginPatternCommandsPreCommandRunListener } from './PluginPreCommandRun';


### PR DESCRIPTION
There was an issue that in certain cases the index.ts in the listeners directory acted as a `PreCommandRunListener` clone.
This PR will fix it.