### PR TITLE
feat(scheduled-tasks): add `delete`, `list`, `listRepeated` & `get` methods

### DIFF
--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -41,6 +41,22 @@ export class ScheduledTaskHandler {
 		);
 	}
 
+	public delete(id?: unknown) {
+		return this.strategy.delete(id);
+	}
+
+	public list(options?: unknown) {
+		return this.strategy.list(options);
+	}
+
+	public listRepeated(options?: unknown) {
+		return this.strategy.listRepeated(options);
+	}
+
+	public get(id: unknown) {
+		return this.strategy.get(id);
+	}
+
 	public async run(task: string, payload: unknown): Promise<unknown> {
 		const piece = this.store.get(task);
 

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -85,7 +85,7 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 			return;
 		}
 
-		const job = await this.bullClient.getJob(id);
+		const job = await this.get(id);
 		return job?.remove();
 	}
 
@@ -107,12 +107,12 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 		return this.bullClient.getRepeatableJobs(start, end, asc);
 	}
 
-	public get(id: JobId): undefined | Promise<Job> {
+	public get(id: JobId) {
 		if (!this.bullClient) {
 			return;
 		}
 
-		return this.get(id);
+		return this.bullClient.getJob(id);
 	}
 
 	public run(task: string, payload: unknown) {

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -87,6 +87,22 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 		return this.bullClient.getJobs(types, start, end, asc);
 	}
 
+	public listRepeated(start?: number, end?: number, asc?: boolean) {
+		if (!this.bullClient) {
+			return;
+		}
+
+		return this.bullClient.getRepeatableJobs(start, end, asc);
+	}
+
+	public get(id: JobId) {
+		if (!this.bullClient) {
+			return;
+		}
+
+		return this.bullClient.getJob(id);
+	}
+
 	public run(task: string, payload: unknown) {
 		return container.tasks.run(task, payload);
 	}

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -1,5 +1,5 @@
 import { container, from, isErr } from '@sapphire/framework';
-import Bull, { Job, JobOptions, Queue, QueueOptions } from 'bull';
+import Bull, { Job, JobOptions, Queue, QueueOptions, JobStatus, JobId } from 'bull';
 import type { ScheduledTaskCreateRepeatedTask, ScheduledTasksTaskOptions } from '../types';
 import type { ScheduledTaskBaseStrategy } from '../types/ScheduledTaskBaseStrategy';
 import { ScheduledTaskEvents } from '../types/ScheduledTaskEvents';
@@ -68,6 +68,23 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 		for (const task of tasks) {
 			await this.create(task.name, null, task.options);
 		}
+	}
+
+	public async delete(id: JobId) {
+		if (!this.bullClient) {
+			return;
+		}
+
+		const job = await this.bullClient.getJob(id);
+		return job?.remove();
+	}
+
+	public list(types: JobStatus[], start?: number, end?: number, asc?: boolean) {
+		if (!this.bullClient) {
+			return;
+		}
+
+		return this.bullClient.getJobs(types, start, end, asc);
 	}
 
 	public run(task: string, payload: unknown) {

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -14,6 +14,16 @@ export interface ScheduledTaskRedisStrategyJob {
 	payload?: unknown;
 }
 
+export interface ScheduledTaskRedisStrategyListRepeatedOptions {
+	start?: number;
+	end?: number;
+	asc?: boolean;
+}
+
+export interface ScheduledTaskRedisStrategyListOptions extends ScheduledTaskRedisStrategyListRepeatedOptions {
+	types: JobStatus[];
+}
+
 export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 	public readonly options: QueueOptions;
 	public readonly queue: string;
@@ -79,7 +89,8 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 		return job?.remove();
 	}
 
-	public list(types: JobStatus[], start?: number, end?: number, asc?: boolean) {
+	public list(options: ScheduledTaskRedisStrategyListOptions) {
+		const { types, start, end, asc } = options;
 		if (!this.bullClient) {
 			return;
 		}
@@ -87,7 +98,8 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 		return this.bullClient.getJobs(types, start, end, asc);
 	}
 
-	public listRepeated(start?: number, end?: number, asc?: boolean) {
+	public listRepeated(options: ScheduledTaskRedisStrategyListRepeatedOptions) {
+		const { start, end, asc } = options;
 		if (!this.bullClient) {
 			return;
 		}
@@ -95,12 +107,12 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 		return this.bullClient.getRepeatableJobs(start, end, asc);
 	}
 
-	public get(id: JobId) {
+	public get(id: JobId): undefined | Promise<Job> {
 		if (!this.bullClient) {
 			return;
 		}
 
-		return this.bullClient.getJob(id);
+		return this.get(id);
 	}
 
 	public run(task: string, payload: unknown) {

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
@@ -65,6 +65,22 @@ export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy {
 		}
 	}
 
+	public delete() {
+		throw new Error('SQS does not support deleting tasks.');
+	}
+
+	public list() {
+		throw new Error('SQS does not support listing tasks.');
+	}
+
+	public listRepeated() {
+		throw new Error('SQS does not support listing tasks.');
+	}
+
+	public get() {
+		throw new Error('SQS does not support getting tasks.');
+	}
+
 	public run(task: string, payload: unknown) {
 		return container.tasks.run(task, payload);
 	}

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTaskBaseStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTaskBaseStrategy.ts
@@ -6,5 +6,9 @@ export interface ScheduledTaskBaseStrategy {
 	connect(): void;
 	create(task: string, payload: unknown, options?: ScheduledTasksTaskOptions): void;
 	createRepeated(tasks: ScheduledTaskCreateRepeatedTask[]): void;
+	delete(id: unknown): void;
+	list(options?: unknown): void;
+	listRepeated(options?: unknown): void;
+	get(id: unknown): void;
 	run(task: string, payload: unknown): Awaitable<unknown>;
 }


### PR DESCRIPTION
Adds 4 new methods:
1. [delete](https://github.com/OptimalBits/bull/blob/HEAD/REFERENCE.md#jobremove): Deletes/removes a job.
2. [list](https://github.com/OptimalBits/bull/blob/HEAD/REFERENCE.md#queuegetjobs): Lists jobs based on the type provided.
3. [listRepeated](https://github.com/OptimalBits/bull/blob/HEAD/REFERENCE.md#queuegetrepeatablejobs): Lists repeatable jobs.
4. [get](https://github.com/OptimalBits/bull/blob/HEAD/REFERENCE.md#queuegetjob): Get's a job of the id provided.