### PR TITLE
Various fixes and a feature for scheduled tasks

### DIFF
--- a/packages/scheduled-tasks/src/index.ts
+++ b/packages/scheduled-tasks/src/index.ts
@@ -5,7 +5,11 @@ import type { ScheduledTasksOptions } from './lib/types/ScheduledTasksOptions';
 export * from './lib/ScheduledTaskHandler';
 export * from './lib/structures/ScheduledTask';
 export * from './lib/structures/ScheduledTaskStore';
-export * from './lib/types';
+export * from './lib/types/ScheduledTaskBaseStrategy';
+export * from './lib/types/ScheduledTaskCreateRepeatedTask';
+export * from './lib/types/ScheduledTaskEvents';
+export * from './lib/types/ScheduledTasksOptions';
+export * from './lib/types/ScheduledTasksTaskOptions';
 
 declare module '@sapphire/pieces' {
 	interface Container {

--- a/packages/scheduled-tasks/src/index.ts
+++ b/packages/scheduled-tasks/src/index.ts
@@ -3,6 +3,15 @@ import type { ScheduledTaskStore } from './lib/structures/ScheduledTaskStore';
 import type { ScheduledTasksOptions } from './lib/types/ScheduledTasksOptions';
 
 export * from './lib/ScheduledTaskHandler';
+export type {
+	BullClient,
+	ScheduledTaskRedisStrategy,
+	ScheduledTaskRedisStrategyJob,
+	ScheduledTaskRedisStrategyListOptions,
+	ScheduledTaskRedisStrategyListRepeatedOptions,
+	ScheduledTaskRedisStrategyOptions
+} from './lib/strategies/ScheduledTaskRedisStrategy';
+export type { ScheduledTaskSQSStrategy, ScheduledTaskSQSStrategyMessageBody, SQSClient } from './lib/strategies/ScheduledTaskSQSStrategy';
 export * from './lib/structures/ScheduledTask';
 export * from './lib/structures/ScheduledTaskStore';
 export * from './lib/types/ScheduledTaskBaseStrategy';

--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -14,6 +14,10 @@ export class ScheduledTaskHandler {
 		this.strategy.connect();
 	}
 
+	public get client(): ScheduledTaskBaseStrategy['client'] {
+		return this.strategy.client;
+	}
+
 	public create(task: string, payload: unknown, options?: ScheduledTasksTaskOptions | number) {
 		if (typeof options === 'number') {
 			options = {

--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -1,8 +1,10 @@
 import { container, fromAsync, isErr } from '@sapphire/framework';
 import { ScheduledTaskRedisStrategy } from './strategies/ScheduledTaskRedisStrategy';
 import type { ScheduledTaskStore } from './structures/ScheduledTaskStore';
-import type { ScheduledTaskBaseStrategy, ScheduledTasksOptions, ScheduledTasksTaskOptions } from './types';
+import type { ScheduledTaskBaseStrategy } from './types/ScheduledTaskBaseStrategy';
 import { ScheduledTaskEvents } from './types/ScheduledTaskEvents';
+import type { ScheduledTasksOptions } from './types/ScheduledTasksOptions';
+import type { ScheduledTasksTaskOptions } from './types/ScheduledTasksTaskOptions';
 
 export class ScheduledTaskHandler {
 	public readonly strategy: ScheduledTaskBaseStrategy;

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -1,8 +1,9 @@
 import { container, from, isErr } from '@sapphire/framework';
-import Bull, { Job, JobOptions, Queue, QueueOptions, JobStatus, JobId } from 'bull';
-import type { ScheduledTaskCreateRepeatedTask, ScheduledTasksTaskOptions } from '../types';
+import Bull, { Job, JobId, JobOptions, JobStatus, Queue, QueueOptions } from 'bull';
 import type { ScheduledTaskBaseStrategy } from '../types/ScheduledTaskBaseStrategy';
+import type { ScheduledTaskCreateRepeatedTask } from '../types/ScheduledTaskCreateRepeatedTask';
 import { ScheduledTaskEvents } from '../types/ScheduledTaskEvents';
+import type { ScheduledTasksTaskOptions } from '../types/ScheduledTasksTaskOptions';
 
 export interface ScheduledTaskRedisStrategyOptions {
 	queue?: string;

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
@@ -1,4 +1,5 @@
 import { container, from, isErr } from '@sapphire/framework';
+import type { SendMessageBatchResultEntryList } from 'aws-sdk/clients/sqs';
 import { randomBytes } from 'crypto';
 import { Consumer, ConsumerOptions } from 'sqs-consumer';
 import { Producer } from 'sqs-producer';
@@ -45,7 +46,7 @@ export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy {
 		}
 	}
 
-	public create(task: string, payload?: unknown, options?: ScheduledTasksTaskOptions) {
+	public create(task: string, payload?: unknown, options?: ScheduledTasksTaskOptions): Promise<SendMessageBatchResultEntryList> {
 		if (options?.cron) {
 			throw new Error('SQS does not support cron notation.');
 		}
@@ -66,29 +67,29 @@ export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy {
 		});
 	}
 
-	public async createRepeated(tasks: ScheduledTaskCreateRepeatedTask[]) {
+	public async createRepeated(tasks: ScheduledTaskCreateRepeatedTask[]): Promise<void> {
 		for (const task of tasks) {
 			await this.create(task.name, null, task.options);
 		}
 	}
 
-	public delete() {
+	public delete(): void {
 		throw new Error('SQS does not support deleting tasks.');
 	}
 
-	public list() {
+	public list(): void {
 		throw new Error('SQS does not support listing tasks.');
 	}
 
-	public listRepeated() {
+	public listRepeated(): void {
 		throw new Error('SQS does not support listing tasks.');
 	}
 
-	public get() {
+	public get(): void {
 		throw new Error('SQS does not support getting tasks.');
 	}
 
-	public run(task: string, payload: unknown) {
+	public run(task: string, payload: unknown): Promise<unknown> {
 		return container.tasks.run(task, payload);
 	}
 

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
@@ -13,14 +13,20 @@ export interface ScheduledTaskSQSStrategyMessageBody {
 	options: ScheduledTasksTaskOptions;
 }
 
+export type SQSClient = Producer;
+
 export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy {
 	public readonly options: ConsumerOptions;
 
-	private producer: Producer;
+	private producer: SQSClient;
 
 	public constructor(options: ConsumerOptions) {
 		this.options = options;
 		this.producer = Producer.create(this.options);
+	}
+
+	public get client(): SQSClient {
+		return this.producer;
 	}
 
 	public connect() {

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
@@ -2,9 +2,10 @@ import { container, from, isErr } from '@sapphire/framework';
 import { randomBytes } from 'crypto';
 import { Consumer, ConsumerOptions } from 'sqs-consumer';
 import { Producer } from 'sqs-producer';
-import type { ScheduledTaskCreateRepeatedTask, ScheduledTasksTaskOptions } from '../types';
 import type { ScheduledTaskBaseStrategy } from '../types/ScheduledTaskBaseStrategy';
+import type { ScheduledTaskCreateRepeatedTask } from '../types/ScheduledTaskCreateRepeatedTask';
 import { ScheduledTaskEvents } from '../types/ScheduledTaskEvents';
+import type { ScheduledTasksTaskOptions } from '../types/ScheduledTasksTaskOptions';
 
 export interface ScheduledTaskSQSStrategyMessageBody {
 	task: string;

--- a/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
+++ b/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
@@ -1,11 +1,11 @@
-import { Piece, PieceContext, PieceOptions } from '@sapphire/pieces';
+import { Piece } from '@sapphire/pieces';
 import type { Awaitable } from '@sapphire/utilities';
 
 export abstract class ScheduledTask extends Piece {
 	public readonly interval: number | null;
 	public readonly cron: string | null;
 
-	public constructor(context: PieceContext, options: ScheduledTaskOptions) {
+	public constructor(context: Piece.Context, options: ScheduledTaskOptions) {
 		super(context, options);
 		this.interval = options.interval ?? null;
 		this.cron = options.cron ?? null;
@@ -16,7 +16,7 @@ export abstract class ScheduledTask extends Piece {
 
 export interface ScheduledTasks {}
 
-export interface ScheduledTaskOptions extends PieceOptions {
+export interface ScheduledTaskOptions extends Piece.Options {
 	interval?: number | null;
 	cron?: string | null;
 }

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTaskBaseStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTaskBaseStrategy.ts
@@ -5,11 +5,11 @@ import type { ScheduledTasksTaskOptions } from './ScheduledTasksTaskOptions';
 export interface ScheduledTaskBaseStrategy {
 	client: unknown;
 	connect(): void;
-	create(task: string, payload: unknown, options?: ScheduledTasksTaskOptions): void;
+	create(task: string, payload: unknown, options?: ScheduledTasksTaskOptions): Awaitable<unknown>;
 	createRepeated(tasks: ScheduledTaskCreateRepeatedTask[]): void;
-	delete(id: unknown): void;
-	list(options?: unknown): void;
-	listRepeated(options?: unknown): void;
-	get(id: unknown): void;
+	delete(id: unknown): unknown;
+	list(options?: unknown): unknown;
+	listRepeated(options?: unknown): unknown;
+	get(id: unknown): unknown;
 	run(task: string, payload: unknown): Awaitable<unknown>;
 }

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTaskBaseStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTaskBaseStrategy.ts
@@ -3,6 +3,7 @@ import type { ScheduledTaskCreateRepeatedTask } from './ScheduledTaskCreateRepea
 import type { ScheduledTasksTaskOptions } from './ScheduledTasksTaskOptions';
 
 export interface ScheduledTaskBaseStrategy {
+	client: unknown;
 	connect(): void;
 	create(task: string, payload: unknown, options?: ScheduledTasksTaskOptions): void;
 	createRepeated(tasks: ScheduledTaskCreateRepeatedTask[]): void;

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTaskEvents.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTaskEvents.ts
@@ -1,8 +1,18 @@
+/**
+ * Events emitted during the process setting up the scheduler and running a task.
+ * You can use these events to trace the progress for debugging purposes.
+ */
 export enum ScheduledTaskEvents {
+	/** Event that is emitted if a task piece is not found in the store */
 	ScheduledTaskNotFound = 'scheduledTaskNotFound',
+	/** Event that is emitted before a task's "run" method is called */
 	ScheduledTaskRun = 'scheduledTaskRun',
+	/** Event that is emitted when a task's "run" method throws an error */
 	ScheduledTaskError = 'scheduledTaskError',
+	/** Event that is emitted when a tasks's "run" method is successful */
 	ScheduledTaskSuccess = 'scheduledTaskSuccess',
+	/** Event that is emitted when a task's "run" method finishes, regardless of whether an error occurred or not */
 	ScheduledTaskFinished = 'scheduledTaskFinished',
+	/** Event that is emitted when the scheduler fails to connect to the server (i.e. redis or sqs) */
 	ScheduledTaskStrategyConnectError = 'scheduledTaskStrategyConnectError'
 }

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTasksOptions.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTasksOptions.ts
@@ -1,4 +1,4 @@
-import type { ScheduledTaskBaseStrategy } from '.';
+import type { ScheduledTaskBaseStrategy } from './ScheduledTaskBaseStrategy';
 
 export interface ScheduledTasksOptions {
 	strategy: ScheduledTaskBaseStrategy;

--- a/packages/scheduled-tasks/src/lib/types/index.ts
+++ b/packages/scheduled-tasks/src/lib/types/index.ts
@@ -1,4 +1,0 @@
-export * from './ScheduledTaskBaseStrategy';
-export * from './ScheduledTaskCreateRepeatedTask';
-export * from './ScheduledTasksOptions';
-export * from './ScheduledTasksTaskOptions';


### PR DESCRIPTION
- fix(scheduled-tasks): fixed export of events enum not being on top level
- fix(scheduled-tasks): added tsdoc for `ScheduledTaskEvents`
- refactor(scheduled-tasks): use namespaced imports
- feat(scheduled-tasks): add getter for the client (So people can stop complaining about it)
- fix(scheduled-tasks): fixed the return types for the strategy methods


closes #210 (superseded)