### PR TITLE
fix(hmr): improve logging

### DIFF
--- a/packages/hmr/src/index.ts
+++ b/packages/hmr/src/index.ts
@@ -7,7 +7,7 @@ import { relative } from 'path';
  * Starts HMR for all registered {@link Store Stores} in {@link container.stores the main container}.
  */
 export function start() {
-	container.logger.info('HMR-Plugin: Enabled.');
+	container.logger.info('[HMR-Plugin]: Enabled. Watching for piece changes.');
 
 	for (const store of container.stores.values()) {
 		const deleteCb = handlePiecePathDelete.bind(null, store);
@@ -27,11 +27,11 @@ async function handlePiecePathDelete(store: Store<Piece>, path: string) {
 
 	const result = await fromAsync(async () => {
 		await pieceToDelete.unload();
-		container.logger.info(`HMR-Plugin: Unloaded ${pieceToDelete.name}.`);
+		container.logger.info(`[HMR-Plugin]: Unloaded piece ${pieceToDelete.name} of ${pieceToDelete.store.name} store.`);
 	});
 
 	if (isErr(result)) {
-		container.logger.error(`HMR-Plugin: Failed to unload ${pieceToDelete.name}.`, error);
+		container.logger.error(`[HMR-Plugin]: Failed to unload piece ${pieceToDelete.name} of ${pieceToDelete.store.name} store.`, error);
 	}
 }
 
@@ -43,18 +43,21 @@ async function handlePiecePathUpdate(store: Store<Piece>, path: string) {
 	const result = await fromAsync(async () => {
 		if (pieceToUpdate) {
 			await pieceToUpdate.reload();
-			container.logger.info(`HMR-Plugin: reloaded ${pieceToUpdate.name}.`);
+			container.logger.info(`[HMR-Plugin]: reloaded piece ${pieceToUpdate.name} of ${pieceToUpdate.store.name} store.`);
 		} else {
 			const rootPath = [...store.paths].find((storePath) => path.startsWith(storePath));
-			if (!rootPath) throw new Error(`HMR-Plugin: Could not find root path for ${path}.`);
+			if (!rootPath) throw new Error(`[HMR-Plugin]: Could not find root path for ${path}.`);
 
-			const commandsLoaded = await store.load(rootPath, relative(rootPath, path));
-			const commandsLoadedNames = commandsLoaded.map((piece) => piece.name);
-			container.logger.info(`HMR-Plugin: Loaded ${commandsLoadedNames.join(', ')}.`);
+			const piecesLoaded = await store.load(rootPath, relative(rootPath, path));
+			const piecesLoadedNames = piecesLoaded.map((piece) => piece.name);
+			const piecesLoadedStoreNames = piecesLoaded.map((piece) => piece.store.name);
+			container.logger.info(
+				`[HMR-Plugin]: Loaded ${piecesLoadedNames.join(', ')} piece(s) of ${[...new Set(piecesLoadedStoreNames)].join(', ')} store(s).`
+			);
 		}
 	});
 
 	if (isErr(result)) {
-		container.logger.error(`HMR-Plugin: Failed to load pieces from ${path}.`, result.error);
+		container.logger.error(`[HMR-Plugin]: Failed to load pieces from ${path}.`, result.error);
 	}
 }

--- a/packages/hmr/src/index.ts
+++ b/packages/hmr/src/index.ts
@@ -27,11 +27,11 @@ async function handlePiecePathDelete(store: Store<Piece>, path: string) {
 
 	const result = await fromAsync(async () => {
 		await pieceToDelete.unload();
-		container.logger.info(`[HMR-Plugin]: Unloaded piece ${pieceToDelete.name} of ${pieceToDelete.store.name} store.`);
+		container.logger.info(`[HMR-Plugin]: Unloaded piece ${pieceToDelete.name} from ${pieceToDelete.store.name} store.`);
 	});
 
 	if (isErr(result)) {
-		container.logger.error(`[HMR-Plugin]: Failed to unload piece ${pieceToDelete.name} of ${pieceToDelete.store.name} store.`, error);
+		container.logger.error(`[HMR-Plugin]: Failed to unload piece ${pieceToDelete.name} from ${pieceToDelete.store.name} store.`, error);
 	}
 }
 
@@ -43,7 +43,7 @@ async function handlePiecePathUpdate(store: Store<Piece>, path: string) {
 	const result = await fromAsync(async () => {
 		if (pieceToUpdate) {
 			await pieceToUpdate.reload();
-			container.logger.info(`[HMR-Plugin]: reloaded piece ${pieceToUpdate.name} of ${pieceToUpdate.store.name} store.`);
+			container.logger.info(`[HMR-Plugin]: reloaded piece ${pieceToUpdate.name} from ${pieceToUpdate.store.name} store.`);
 		} else {
 			const rootPath = [...store.paths].find((storePath) => path.startsWith(storePath));
 			if (!rootPath) throw new Error(`[HMR-Plugin]: Could not find root path for ${path}.`);
@@ -52,7 +52,7 @@ async function handlePiecePathUpdate(store: Store<Piece>, path: string) {
 			const piecesLoadedNames = piecesLoaded.map((piece) => piece.name);
 			const piecesLoadedStoreNames = piecesLoaded.map((piece) => piece.store.name);
 			container.logger.info(
-				`[HMR-Plugin]: Loaded ${piecesLoadedNames.join(', ')} piece(s) of ${[...new Set(piecesLoadedStoreNames)].join(', ')} store(s).`
+				`[HMR-Plugin]: Loaded ${piecesLoadedNames.join(', ')} piece(s) from ${[...new Set(piecesLoadedStoreNames)].join(', ')} store(s).`
 			);
 		}
 	});


### PR DESCRIPTION
This makes the `HMR plugin` logs more descriptive as they can be confusing, for example in cases like updating two pieces with the same name.