### PR TITLE
perf(i18next): "add" event is not necessary in chokidar

### DIFF
--- a/packages/i18next/src/register.ts
+++ b/packages/i18next/src/register.ts
@@ -18,7 +18,7 @@ export class I18nextPlugin extends Plugin {
 			container.logger.info('[i18next-Plugin]: HMR enabled. Watching for languages changes.');
 			const hmr = watch(container.i18n.languagesDirectory, this.options.i18n.hmr.options);
 
-			for (const event of ['add', 'change', 'unlink']) hmr.on(event, () => container.i18n.reloadResources());
+			for (const event of ['change', 'unlink']) hmr.on(event, () => container.i18n.reloadResources());
 		}
 	}
 }


### PR DESCRIPTION
I have tested and it works fine without that event, and the problem with that event is that it is executed many times when starting the bot.

This happens when starting the bot with the "add" event of chokidar
![image](https://user-images.githubusercontent.com/56084970/149602842-ff79d3c5-4f81-420b-baea-f3981259470b.png)