### PR TITLE
feat(scheduled-tasks): make it possible to configure additional Job options when using Redis strategy

### DIFF
--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -40,9 +40,15 @@ export class ScheduledTaskHandler {
 					type: 'repeated',
 					...(piece.interval
 						? {
-								interval: piece.interval
+								interval: piece.interval,
+								removeOnComplete: piece.removeOnComplete,
+								removeOnFail: piece.removeOnFail
 						  }
-						: { cron: piece.cron! })
+						: {
+								cron: piece.cron!,
+								removeOnComplete: piece.removeOnComplete,
+								removeOnFail: piece.removeOnFail
+						  })
 				}
 			}))
 		);

--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -80,9 +80,7 @@ export class ScheduledTaskHandler {
 			container.client.emit(ScheduledTaskEvents.ScheduledTaskRun, task, payload);
 
 			const stopwatch = new Stopwatch();
-
 			const taskRunResult = await piece.run(payload);
-
 			const { duration } = stopwatch.stop();
 
 			container.client.emit(ScheduledTaskEvents.ScheduledTaskSuccess, task, payload, taskRunResult, duration);

--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -41,13 +41,11 @@ export class ScheduledTaskHandler {
 					...(piece.interval
 						? {
 								interval: piece.interval,
-								removeOnComplete: piece.removeOnComplete,
-								removeOnFail: piece.removeOnFail
+								bullJobOptions: piece.bullJobOptions
 						  }
 						: {
 								cron: piece.cron!,
-								removeOnComplete: piece.removeOnComplete,
-								removeOnFail: piece.removeOnFail
+								bullJobOptions: piece.bullJobOptions
 						  })
 				}
 			}))

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -72,7 +72,9 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 					  }
 					: {
 							cron: options.cron!
-					  }
+					  },
+				removeOnFail: options.removeOnFail ?? false,
+				removeOnComplete: options.removeOnComplete ?? false
 			};
 		}
 

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -73,8 +73,7 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 					: {
 							cron: options.cron!
 					  },
-				removeOnFail: options.removeOnFail ?? false,
-				removeOnComplete: options.removeOnComplete ?? false
+				...options.bullJobOptions
 			};
 		}
 

--- a/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
+++ b/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
@@ -4,19 +4,30 @@ import type { Awaitable } from '@sapphire/utilities';
 export abstract class ScheduledTask extends Piece {
 	public readonly interval: number | null;
 	public readonly cron: string | null;
+	public readonly removeOnComplete?: boolean | number | undefined;
+	public readonly removeOnFail?: boolean | number | undefined;
 
 	public constructor(context: Piece.Context, options: ScheduledTaskOptions) {
 		super(context, options);
 		this.interval = options.interval ?? null;
 		this.cron = options.cron ?? null;
+
+		// @ts-expect-error For redis strategy this property will actually be defined
+		this.removeOnComplete = options.removeOnComplete ?? false;
+
+		// @ts-expect-error For redis strategy this property will actually be defined
+		this.removeOnFail = options.removeOnFail ?? false;
 	}
 
 	public abstract run(payload: unknown): Awaitable<unknown>;
 }
 
-export interface ScheduledTasks {}
-
 export interface ScheduledTaskOptions extends Piece.Options {
 	interval?: number | null;
 	cron?: string | null;
+}
+
+export namespace ScheduledTask {
+	export type Options = ScheduledTaskOptions;
+	export type Context = Piece.Context;
 }

--- a/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
+++ b/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
@@ -4,8 +4,7 @@ import type { Awaitable } from '@sapphire/utilities';
 export abstract class ScheduledTask extends Piece {
 	public readonly interval: number | null;
 	public readonly cron: string | null;
-	public readonly removeOnComplete?: boolean | number | undefined;
-	public readonly removeOnFail?: boolean | number | undefined;
+	public readonly bullJobOptions?: unknown;
 
 	public constructor(context: Piece.Context, options: ScheduledTaskOptions) {
 		super(context, options);
@@ -13,10 +12,7 @@ export abstract class ScheduledTask extends Piece {
 		this.cron = options.cron ?? null;
 
 		// @ts-expect-error For redis strategy this property will actually be defined
-		this.removeOnComplete = options.removeOnComplete ?? false;
-
-		// @ts-expect-error For redis strategy this property will actually be defined
-		this.removeOnFail = options.removeOnFail ?? false;
+		this.bullJobOptions = options.bullJobOptions;
 	}
 
 	public abstract run(payload: unknown): Awaitable<unknown>;

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTasksTaskOptions.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTasksTaskOptions.ts
@@ -1,7 +1,7 @@
 export type ScheduledTasksTaskOptions = {
 	type: 'default' | 'repeated';
 } & (
-	| { delay: number; interval?: never; cron?: never; removeOnComplete?: boolean | number | undefined; removeOnFail?: boolean | number | undefined }
-	| { delay?: never; interval: number; cron?: never; removeOnComplete?: boolean | number | undefined; removeOnFail?: boolean | number | undefined }
-	| { delay?: never; interval?: never; cron: string; removeOnComplete?: boolean | number | undefined; removeOnFail?: boolean | number | undefined }
+	| { delay: number; interval?: never; cron?: never; bullJobOptions?: any }
+	| { delay?: never; interval: number; cron?: never; bullJobOptions?: any }
+	| { delay?: never; interval?: never; cron: string; bullJobOptions?: any }
 );

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTasksTaskOptions.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTasksTaskOptions.ts
@@ -1,7 +1,7 @@
 export type ScheduledTasksTaskOptions = {
 	type: 'default' | 'repeated';
 } & (
-	| { delay: number; interval?: never; cron?: never }
-	| { delay?: never; interval: number; cron?: never }
-	| { delay?: never; interval?: never; cron: string }
+	| { delay: number; interval?: never; cron?: never; removeOnComplete?: boolean | number | undefined; removeOnFail?: boolean | number | undefined }
+	| { delay?: never; interval: number; cron?: never; removeOnComplete?: boolean | number | undefined; removeOnFail?: boolean | number | undefined }
+	| { delay?: never; interval?: never; cron: string; removeOnComplete?: boolean | number | undefined; removeOnFail?: boolean | number | undefined }
 );

--- a/packages/scheduled-tasks/src/register-redis.ts
+++ b/packages/scheduled-tasks/src/register-redis.ts
@@ -1,3 +1,4 @@
+import type { JobOptions } from 'bull';
 import './index';
 import './register';
 
@@ -6,18 +7,6 @@ export * from './lib/strategies/ScheduledTaskRedisStrategy';
 // @ts-expect-error this will work for end-users but TS doesn't like module augmenting itself
 declare module '@sapphire/plugin-scheduled-tasks' {
 	interface ScheduledTaskOptions {
-		/**
-		 * A boolean which, if true, removes the job when it successfully completes.
-		 * When a number, it specifies the amount of jobs to keep.
-		 * Default behavior is to keep the job in the completed set.
-		 */
-		removeOnComplete?: boolean | number | undefined;
-
-		/**
-		 * A boolean which, if true, removes the job when it fails after all attempts.
-		 * When a number, it specifies the amount of jobs to keep.
-		 * Default behavior is to keep the job in the failed set.
-		 */
-		removeOnFail?: boolean | number | undefined;
+		bullJobOptions?: Omit<JobOptions, 'repeat'>;
 	}
 }

--- a/packages/scheduled-tasks/src/register-redis.ts
+++ b/packages/scheduled-tasks/src/register-redis.ts
@@ -2,3 +2,22 @@ import './index';
 import './register';
 
 export * from './lib/strategies/ScheduledTaskRedisStrategy';
+
+// @ts-expect-error this will work for end-users but TS doesn't like module augmenting itself
+declare module '@sapphire/plugin-scheduled-tasks' {
+	interface ScheduledTaskOptions {
+		/**
+		 * A boolean which, if true, removes the job when it successfully completes.
+		 * When a number, it specifies the amount of jobs to keep.
+		 * Default behavior is to keep the job in the completed set.
+		 */
+		removeOnComplete?: boolean | number | undefined;
+
+		/**
+		 * A boolean which, if true, removes the job when it fails after all attempts.
+		 * When a number, it specifies the amount of jobs to keep.
+		 * Default behavior is to keep the job in the failed set.
+		 */
+		removeOnFail?: boolean | number | undefined;
+	}
+}


### PR DESCRIPTION
My Redis store was getting filled with keys of failed tasks, turns out they can actually be removed by bull.

![image](https://user-images.githubusercontent.com/4019718/150651740-86bab991-8148-4846-a2d8-4514a239ea13.png)


Control clicking takes me to `/register-redis` file where the module declaration is

And bull created it with the options correctly:
```json
{
  "repeat": {
    "count": 1,
    "key": "__default__::::*/10 * * * *",
    "cron": "*/10 * * * *"
  },
  "jobId": "repeat:521cc9772a578b272b59a27d7a892cd9:1642874400000",
  "delay": 441492,
  "timestamp": 1642873958508,
  "prevMillis": 1642874400000,
  "removeOnFail": true,
  "removeOnComplete": true,
  "attempts": 1
}

```