### PR TITLE
fix(schedules-tasks): create cron scheduled tasks with unique names to avoid name conflicts, causing tasks to be ignored

### DIFF
--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -77,13 +77,7 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 			};
 		}
 
-		return this.bullClient.add(
-			{
-				task,
-				payload
-			},
-			bullOptions
-		) as Promise<Bull.Job<ScheduledTaskRedisStrategyJob<T>>> | undefined;
+		return this.bullClient.add(task, payload as any, bullOptions) as Promise<Bull.Job<ScheduledTaskRedisStrategyJob<T>>> | undefined;
 	}
 
 	public async createRepeated(tasks: ScheduledTaskCreateRepeatedTask[]): Promise<void> {


### PR DESCRIPTION
By default the tasks were registered with the name "__ default __", so bull was confused by having tasks with the same name and overwrote them.