### PR TITLE
Additional feature and 2 fixes for i18next

### DIFF
--- a/packages/i18next/src/lib/functions.ts
+++ b/packages/i18next/src/lib/functions.ts
@@ -327,9 +327,17 @@ export async function editLocalized<TKeys extends TFunctionKeys = string, TInter
 export async function editLocalized<TKeys extends TFunctionKeys = string, TInterpolationMap extends NonNullObject = StringMap>(
 	target: BaseCommandInteraction | Message | MessageComponentInteraction,
 	options: TKeys | TKeys[] | LocalizedMessageOptions<TKeys, TInterpolationMap> | LocalizedInteractionReplyOptions<TKeys, TInterpolationMap>
-): Promise<ReturnType<(BaseCommandInteraction | MessageComponentInteraction)['editReply']> | Message> {
+): Promise<
+	| ReturnType<(BaseCommandInteraction | MessageComponentInteraction)['editReply']>
+	| ReturnType<(BaseCommandInteraction | MessageComponentInteraction)['reply']>
+	| Message
+> {
 	if (target instanceof BaseCommandInteraction || target instanceof MessageComponentInteraction) {
-		return target.editReply(await resolveOverloads(target, options));
+		if (target.deferred || target.replied) {
+			return target.editReply(await resolveOverloads(target, options));
+		}
+
+		return target.reply(await resolveOverloads(target, options));
 	}
 
 	return target.edit(await resolveOverloads(target, options));

--- a/packages/i18next/src/lib/functions.ts
+++ b/packages/i18next/src/lib/functions.ts
@@ -235,7 +235,15 @@ export async function replyLocalized<TKeys extends TFunctionKeys = string, TInte
 		) => Promise<ReturnType<(BaseCommandInteraction | MessageComponentInteraction)['reply']> | Message>;
 	},
 	options: TKeys | TKeys[] | LocalizedMessageOptions<TKeys, TInterpolationMap> | LocalizedInteractionReplyOptions<TKeys, TInterpolationMap>
-): Promise<ReturnType<(BaseCommandInteraction | MessageComponentInteraction)['reply']> | Message> {
+): Promise<
+	ReturnType<(BaseCommandInteraction | MessageComponentInteraction)['reply']> | ReturnType<MessageComponentInteraction['update']> | Message
+> {
+	if (target instanceof BaseCommandInteraction || target instanceof MessageComponentInteraction) {
+		if (target.deferred || target.replied) {
+			return target.editReply(await resolveOverloads(target, options)) as Promise<Message<boolean>>;
+		}
+	}
+
 	return target.reply(await resolveOverloads(target, options));
 }
 

--- a/packages/i18next/src/lib/functions.ts
+++ b/packages/i18next/src/lib/functions.ts
@@ -1,5 +1,5 @@
 import { container } from '@sapphire/pieces';
-import { isObject, NonNullObject } from '@sapphire/utilities';
+import { cast, isObject, NonNullObject } from '@sapphire/utilities';
 import {
 	BaseCommandInteraction,
 	Guild,
@@ -35,7 +35,13 @@ import type {
 export function fetchLanguage(target: Target): Promise<string> {
 	// Handle Interactions:
 	if (target instanceof BaseCommandInteraction || target instanceof MessageComponentInteraction) {
-		return resolveLanguage({ user: target.user, channel: target.channel, guild: target.guild });
+		return resolveLanguage({
+			user: target.user,
+			channel: target.channel,
+			guild: target.guild,
+			interactionGuildLocale: target.guildLocale,
+			interactionLocale: target.locale
+		});
 	}
 
 	// Handle Message:
@@ -371,7 +377,7 @@ async function resolveOverloads<TKeys extends TFunctionKeys = string, TInterpola
 	options: TKeys | TKeys[] | LocalizedMessageOptions<TKeys, TInterpolationMap> | LocalizedInteractionReplyOptions<TKeys, TInterpolationMap>
 ) {
 	if (isObject(options)) {
-		const casted = options as LocalizedMessageOptions<TKeys, TInterpolationMap> | LocalizedInteractionReplyOptions<TKeys, TInterpolationMap>;
+		const casted = cast<LocalizedMessageOptions<TKeys, TInterpolationMap> | LocalizedInteractionReplyOptions<TKeys, TInterpolationMap>>(options);
 		return { ...options, content: await resolveKey(target, casted.keys, casted.formatOptions) };
 	}
 

--- a/packages/i18next/src/lib/types.ts
+++ b/packages/i18next/src/lib/types.ts
@@ -3,6 +3,7 @@ import type { WatchOptions } from 'chokidar';
 import type {
 	BaseCommandInteraction,
 	Guild,
+	Interaction,
 	InteractionReplyOptions,
 	Message,
 	MessageComponentInteraction,
@@ -143,6 +144,8 @@ export interface InternationalizationContext {
 	author?: User | null;
 	/** The user to fetch the preferred language for. */
 	user: User | null;
+	interactionGuildLocale?: Interaction['guildLocale'];
+	interactionLocale?: Interaction['locale'];
 }
 
 export interface InternationalizationClientOptions {


### PR DESCRIPTION
- feat(i18next): add `guildLocale` and `locale` to `fetchLanguage` context
- fix(i18next): ensure an interaction is deferred or replied before editing
- fix(i18next): edit a reply when an already deferred or edited reply is passed into `replyLocalized`

Needs rebase & merge
