### PR TITLE
Pattern commands: PatternCommandAccepted event parameter standardization

### DIFF
--- a/packages/pattern-commands/src/lib/utils/PatternCommandInterfaces.ts
+++ b/packages/pattern-commands/src/lib/utils/PatternCommandInterfaces.ts
@@ -21,3 +21,13 @@ export interface PatternCommandAcceptedPayload extends PatternCommandPayload {
 	parameters: string;
 	context: PatternCommand.RunContext;
 }
+
+export interface PatternCommandSuccessPayload extends PatternCommandFinishedPayload {
+	result: unknown;
+}
+
+export interface PatternCommandFinishedPayload extends PatternCommandAcceptedPayload {
+	duration: number;
+}
+
+export interface PatternCommandErrorPayload extends PatternCommandFinishedPayload {}

--- a/packages/pattern-commands/src/listeners/PluginCommandAccepted.ts
+++ b/packages/pattern-commands/src/listeners/PluginCommandAccepted.ts
@@ -20,24 +20,24 @@ export class CommandAcceptedListener extends Listener<typeof PatternCommandEvent
 	}
 
 	public async runPatternCommand(payload: PatternCommandAcceptedPayload) {
-		const { message, command, alias } = payload;
+		const { message, command } = payload;
 
 		const result = await fromAsync(async () => {
-			message.client.emit(PatternCommandEvents.CommandRun, message, command, alias);
+			message.client.emit(PatternCommandEvents.CommandRun, message, command, payload);
 
 			const stopwatch = new Stopwatch();
 			const result = await command.messageRun(message);
 			const { duration } = stopwatch.stop();
 
-			message.client.emit(PatternCommandEvents.CommandSuccess, result, command, alias, duration);
+			message.client.emit(PatternCommandEvents.CommandSuccess, { ...payload, result, duration });
 
 			return duration;
 		});
 
 		if (isErr(result)) {
-			message.client.emit(PatternCommandEvents.CommandError, result.error, command, payload);
+			message.client.emit(PatternCommandEvents.CommandError, result.error, { ...payload, duration: result.value ?? -1 });
 		}
 
-		message.client.emit(PatternCommandEvents.CommandFinished, command, result.value, payload);
+		message.client.emit(PatternCommandEvents.CommandFinished, message, command, { ...payload, duration: result.value ?? -1 });
 	}
 }


### PR DESCRIPTION
With this the events in PatternCommandAccepted will use the same structure as in the events in [CoreMessageCommandAccepted](https://github.com/sapphiredev/framework/blob/9ed3d983eaaf4251380b237be73a251a424059bf/src/optional-listeners/message-command-listeners/CoreMessageCommandAccepted.ts)