### PR TITLE
docs(pattern-commands): update message intent deadline

### DIFF
--- a/packages/pattern-commands/README.md
+++ b/packages/pattern-commands/README.md
@@ -19,7 +19,7 @@ With pattern commands you can define rulesets to which the bot may respond.
 
 ## Important notes
 
--   Starting April 2022 this plugin will only work with Message Intent. This is because this plugin relies on scanning messages, which is impossible without the intent.
+-   Starting August 31, 2022 this plugin will only work with Message Intent. This is because this plugin relies on scanning messages, which is impossible without the intent.
 
 ## Features
 


### PR DESCRIPTION
This PR updates the message intent deadline in the README of the pattern commands plugin to reflect the updated deadline:
https://support-dev.discord.com/hc/en-us/articles/4404772028055