### PR TITLE
feat(plugin-pattern-commands): add success property to finished payload

### DIFF
--- a/packages/pattern-commands/src/lib/utils/PatternCommandInterfaces.ts
+++ b/packages/pattern-commands/src/lib/utils/PatternCommandInterfaces.ts
@@ -28,6 +28,7 @@ export interface PatternCommandSuccessPayload extends PatternCommandFinishedPayl
 
 export interface PatternCommandFinishedPayload extends PatternCommandAcceptedPayload {
 	duration: number;
+	success: boolean;
 }
 
 export interface PatternCommandErrorPayload extends PatternCommandFinishedPayload {}

--- a/packages/pattern-commands/src/listeners/PluginCommandAccepted.ts
+++ b/packages/pattern-commands/src/listeners/PluginCommandAccepted.ts
@@ -38,6 +38,10 @@ export class CommandAcceptedListener extends Listener<typeof PatternCommandEvent
 			message.client.emit(PatternCommandEvents.CommandError, result.error, { ...payload, duration: result.value ?? -1 });
 		}
 
-		message.client.emit(PatternCommandEvents.CommandFinished, message, command, { ...payload, duration: result.value ?? -1 });
+		message.client.emit(PatternCommandEvents.CommandFinished, message, command, {
+			...payload,
+			success: !isErr(result),
+			duration: result.value ?? -1
+		});
 	}
 }


### PR DESCRIPTION
This PR adds the feature proposed in sapphiredev/framework#470 to the PatternCommands plugin as well