### PR TITLE
fix: end response only if options route handler is not present

### DIFF
--- a/packages/api/src/middlewares/headers.ts
+++ b/packages/api/src/middlewares/headers.ts
@@ -41,7 +41,9 @@ export class PluginMiddleware extends Middleware {
 	 */
 	private ensurePotentialEarlyExit(request: ApiRequest, response: ApiResponse, route: Route | null) {
 		if (request.method === 'OPTIONS') {
-			response.end();
+			if (!route || !route.methods.has('OPTIONS')) {
+				response.end();
+			}
 		} else if (route === null) {
 			response.status(HttpCodes.NotFound).end();
 		}


### PR DESCRIPTION
This PR implements a fix for `plugin-api`.

Now, we first check if the route has a listener/handler for the `OPTIONS` type request and if the handler is present then let the custom handler execute. If no handler is present it still ends with `response.end()`.