### PR TITLE
fix(scheduled-tasks): various register fixes

### DIFF
--- a/packages/scheduled-tasks/package.json
+++ b/packages/scheduled-tasks/package.json
@@ -13,6 +13,11 @@
 			"require": "./dist/index.js",
 			"types": "./dist/index.d.ts"
 		},
+		"./register": {
+			"import": "./register.mjs",
+			"require": "./register.js",
+			"types": "./register.d.ts"
+		},
 		"./register-redis": {
 			"import": "./register-redis.mjs",
 			"require": "./register-redis.js",
@@ -35,8 +40,11 @@
 		}
 	},
 	"sideEffects": [
+		"./dist/register.js",
 		"./dist/register-redis.js",
 		"./dist/register-sqs.js",
+		"./register.js",
+		"./register.mjs",
 		"./register-redis.js",
 		"./register-redis.mjs",
 		"./register-sqs.js",
@@ -45,7 +53,8 @@
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/scheduled-tasks",
 	"scripts": {
 		"lint": "eslint src --ext ts --fix",
-		"build": "tsc -b src && yarn esm:register-redis && yarn esm:register-sqs && yarn esm:default",
+		"build": "tsc -b src && yarn esm:register && yarn esm:register-redis && yarn esm:register-sqs && yarn esm:default",
+		"esm:register": "gen-esm-wrapper dist/register.js dist/register.mjs",
 		"esm:register-redis": "gen-esm-wrapper dist/register-redis.js dist/register-redis.mjs",
 		"esm:register-sqs": "gen-esm-wrapper dist/register-sqs.js dist/register-sqs.mjs",
 		"esm:default": "gen-esm-wrapper dist/index.js dist/index.mjs",
@@ -78,6 +87,7 @@
 		"dist/**/*.js*",
 		"dist/**/*.mjs*",
 		"dist/**/*.d*",
+		"./register.*",
 		"./register-redis.*",
 		"./register-sqs.*",
 		"./types-redis.*",

--- a/packages/scheduled-tasks/register.d.ts
+++ b/packages/scheduled-tasks/register.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/register';

--- a/packages/scheduled-tasks/register.js
+++ b/packages/scheduled-tasks/register.js
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const tslib = require('tslib');
+
+tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/scheduled-tasks/register.mjs
+++ b/packages/scheduled-tasks/register.mjs
@@ -1,0 +1,1 @@
+export * from './dist/register.mjs';

--- a/packages/scheduled-tasks/types-redis.js
+++ b/packages/scheduled-tasks/types-redis.js
@@ -1,4 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const tslib = require('tslib');
 
-tslib.__exportStar(require('./dist/types-sqs.js'), exports);
+tslib.__exportStar(require('./dist/types-redis.js'), exports);

--- a/packages/scheduled-tasks/types-redis.mjs
+++ b/packages/scheduled-tasks/types-redis.mjs
@@ -1,1 +1,1 @@
-export * from './dist/types-sqs.mjs';
+export * from './dist/types-redis.mjs';


### PR DESCRIPTION
I'm in the process of creating my own custom strategy for this package.

However I faced a major problem: i obviously won't call `/register-redis`/`/register-sqs` obviously, so i have to call `/register` but it won't let me do it because it is not exposed! neither `@sapphire/plugin-scheduled-tasks/register`, nor `@sapphire/plugin-scheduled-tasks/dist/register` work.

This PR fixes that.
And also a little c/p mismatch I found in top-level `/types-redis`