### PR TITLE
refactor(scheduled-task): remove `@types/ioredis`, require ioredis v5, and bump bullmq

### DIFF
--- a/packages/scheduled-tasks/README.md
+++ b/packages/scheduled-tasks/README.md
@@ -42,9 +42,6 @@ You can use the following command to install this package along with `bullmq`, o
 
 ```sh
 npm install @sapphire/plugin-scheduled-tasks @sapphire/framework @sapphire/stopwatch bullmq
-
-// If you are using TypeScript, you need to install the @types/ioredis types
-npm install @types/ioredis --save-dev
 ```
 
 or with `sqs`

--- a/packages/scheduled-tasks/package.json
+++ b/packages/scheduled-tasks/package.json
@@ -60,8 +60,7 @@
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^1.8.7",
-		"@types/ioredis": "^4.28.10",
-		"bullmq": "^1.90.1",
+		"bullmq": "^1.91.1",
 		"gen-esm-wrapper": "^1.1.3",
 		"sqs-consumer": "^5.7.0",
 		"sqs-producer": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,8 +729,7 @@ __metadata:
   dependencies:
     "@favware/cliff-jumper": ^1.8.7
     "@sapphire/time-utilities": ^1.7.6
-    "@types/ioredis": ^4.28.10
-    bullmq: ^1.90.1
+    bullmq: ^1.91.1
     gen-esm-wrapper: ^1.1.3
     sqs-consumer: ^5.7.0
     sqs-producer: ^2.1.0
@@ -896,15 +895,6 @@ __metadata:
   version: 4.3.3
   resolution: "@types/chai@npm:4.3.3"
   checksum: 20cd094753e137cfc35939cae7f0ed78ecda7861e5c94704efab6979b9121a63807e9b631bdcf3a2792d6c6dba44050b13387262f9e63ebb040741c01c345f0a
-  languageName: node
-  linkType: hard
-
-"@types/ioredis@npm:^4.28.10":
-  version: 4.28.10
-  resolution: "@types/ioredis@npm:4.28.10"
-  dependencies:
-    "@types/node": "*"
-  checksum: 0f2788cf25f490d3b345db8c5f8b8ce3f6c92cc99abcf744c8f974f02b9b3875233b3d22098614c462a0d6c41c523bd655509418ea88eb6249db6652290ce7cf
   languageName: node
   linkType: hard
 
@@ -1618,9 +1608,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bullmq@npm:^1.90.1":
-  version: 1.90.1
-  resolution: "bullmq@npm:1.90.1"
+"bullmq@npm:^1.91.1":
+  version: 1.91.1
+  resolution: "bullmq@npm:1.91.1"
   dependencies:
     cron-parser: ^4.6.0
     get-port: 6.1.2
@@ -1630,8 +1620,8 @@ __metadata:
     msgpackr: ^1.6.2
     semver: ^7.3.7
     tslib: ^2.0.0
-    uuid: ^8.3.2
-  checksum: 14e249db622bf50d918661e87bb5e6e4133becabaa3097e350b6cb5abebe81155613c43b60246036d12c020e9b7857a0c5724d64732631908c18a65d68cbd3b6
+    uuid: ^9.0.0
+  checksum: b433c4c69bde4f9dec8cf8e188bddfda33ae4f430ed3e58beb0bf233c9361e8380b99926fa38f355dd042449a7b4aa1e85c46441e0a9f905df30c81cab4be7c1
   languageName: node
   linkType: hard
 
@@ -6609,6 +6599,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
They finally support ioredis version5, I don't know what else can describe how happy i am while opening this PR 😂 