### PR TITLE
fix: default subcommand argument behavior

### DIFF
--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -128,7 +128,7 @@ export class Subcommand<PreParseReturn extends Args = Args, O extends Subcommand
 			mapping.type ??= 'method';
 
 			if (mapping.type === 'method') {
-				if (mapping.default) {
+				if (mapping.default && !defaultCommand) {
 					matchedWithGroupedSubcommand = false;
 					defaultCommand = mapping;
 				}
@@ -184,11 +184,7 @@ export class Subcommand<PreParseReturn extends Args = Args, O extends Subcommand
 
 		// No subcommand matched, let's try to run default, if any:
 		if (defaultCommand) {
-			if (subcommandOrGroup.isSome()) {
-				args.next();
-			}
-
-			// If we matched with a subcommand in a group we need to skip 1 more arg
+			// If we matched with a subcommand in a group we need to skip 1 the group name
 			if (matchedWithGroupedSubcommand) {
 				args.next();
 			}


### PR DESCRIPTION
This PR fixed the behavior of which default subcommand runs and what arguments get passed to it. With this fix, if a valid group is provided that has a default subcommand, it will always run the default subcommand in that group and will only strip away one argument, the group name. If no valid group or subcommand is given but a top level default subcommand exists, the top level default will run and no arguments will be removed. Below is an example and the code used to generate it.

<details>
  <summary>Example screenshot</summary>

![image](https://cdn.discordapp.com/attachments/737142940777971773/1024011412516905022/unknown.png)
</details>

<details>
  <summary>Test command file used</summary>

  ````ts
import { ApplyOptions } from '@sapphire/decorators';
import type { Args } from '@sapphire/framework';
import { Subcommand } from '@sapphire/plugin-subcommands';
import type { Message } from 'discord.js';

@ApplyOptions<Subcommand.Options>({
  aliases: ['sg'],
  description: 'A message command command with some subcommand groups',
  subcommands: [
    {
      type: 'group',
      name: 'config',
      entries: [
        { name: 'edit', messageRun: 'configEdit' },
        { name: 'show', messageRun: 'configShow' }, //, default: true },
        { name: 'remove', messageRun: 'configRemove' },
        { name: 'reset', messageRun: 'configReset' }
      ]
    },
    {
      type: 'method',
      name: 'help',
      messageRun: 'help',
      default: true
    }
  ]
})
export class UserCommand extends Subcommand {
  public async help(message: Message, args: Args) {
	const allArgs = (await args.restResult('string')).unwrapOr('no args received');
    return message.channel.send(`Source: 'help'; Args: \`\`\`${allArgs}\`\`\``);
  }

  public async configShow(message: Message, args: Args) {
    const allArgs = (await args.restResult('string')).unwrapOr('no args received');
    return message.channel.send(`Source: 'configShow'; Args: \`\`\`${allArgs}\`\`\``);
  }

  public async configEdit(message: Message, args: Args) {
	const allArgs = (await args.restResult('string')).unwrapOr('no args received');
    return message.channel.send(`Source: 'configEdit'; Args: \`\`\`${allArgs}\`\`\``);
  }

  public async configRemove(message: Message, args: Args) {
    const allArgs = (await args.restResult('string')).unwrapOr('no args received');
    return message.channel.send(`Source: 'configRemove'; Args: \`\`\`${allArgs}\`\`\``);
  }

  public async configReset(message: Message, args: Args) {
    const allArgs = (await args.restResult('string')).unwrapOr('no args received');
    return message.channel.send(`Source: 'configReset'; Args: \`\`\`${allArgs}\`\`\``);
  }
}

  ````
</details>

This PR closes #351 