### PR TITLE
feat(plugin-i18next): add `applyLocalizedBuilder` and `createSelectMenuChoiceName` to help registering localized commands

### DIFF
--- a/packages/i18next/src/lib/functions.ts
+++ b/packages/i18next/src/lib/functions.ts
@@ -102,7 +102,7 @@ const getLocales = lazy(() => {
 		if (!isSupportedDiscordLocale(locale)) {
 			process.emitWarning('Unsupported Discord locale', {
 				code: 'UNSUPPORTED_LOCALE',
-				detail: `'${locale}' needs to be one of: ${[...locales.values()]}`
+				detail: `'${locale}' needs to be one of: ${[...locales.keys()]}`
 			});
 
 			locales.delete(locale);

--- a/packages/i18next/src/lib/functions.ts
+++ b/packages/i18next/src/lib/functions.ts
@@ -1,8 +1,16 @@
 import { container } from '@sapphire/pieces';
-import type { NonNullObject } from '@sapphire/utilities';
+import { lazy, type NonNullObject } from '@sapphire/utilities';
+import { Locale, type LocaleString, type LocalizationMap } from 'discord-api-types/v10';
 import { BaseCommandInteraction, Guild, Message, MessageComponentInteraction } from 'discord.js';
 import type { StringMap, TFunctionKeys, TFunctionResult, TOptions } from 'i18next';
-import type { InternationalizationContext, Target } from './types';
+import type {
+	BuilderWithDescription,
+	BuilderWithName,
+	BuilderWithNameAndDescription,
+	InternationalizationContext,
+	LocalizedData,
+	Target
+} from './types';
 
 /**
  * Retrieves the language name for a specific target, using {@link InternationalizationHandler.fetchLanguage}.
@@ -79,4 +87,107 @@ export async function resolveKey<
 async function resolveLanguage(context: InternationalizationContext): Promise<string> {
 	const lang = await container.i18n.fetchLanguage(context);
 	return lang ?? context.guild?.preferredLocale ?? container.i18n.options.defaultName ?? 'en-US';
+}
+
+const supportedLanguages = new Set(Object.values(Locale)) as ReadonlySet<LocaleString>;
+function isSupportedDiscordLocale(language: string): language is LocaleString {
+	return supportedLanguages.has(language as LocaleString);
+}
+
+const getLocales = lazy(() => {
+	const locales = new Map(container.i18n.languages);
+	for (const [locale] of locales) {
+		if (!isSupportedDiscordLocale(locale)) {
+			process.emitWarning('Unsupported Discord locale', {
+				code: 'UNSUPPORTED_LOCALE',
+				detail: `'${locale}' is not assignable to type LocaleString`
+			});
+			locales.delete(locale);
+		}
+		continue;
+	}
+	return locales;
+});
+const getDefaultT = lazy(() => {
+	const defaultLocale = container.i18n.options.defaultName ?? 'en-US';
+	if (!isSupportedDiscordLocale(defaultLocale))
+		throw new TypeError(`Unsupported Discord locale\n'${defaultLocale}' is not assignable to type LocaleString`);
+	const defaultT = getLocales().get(defaultLocale);
+	if (defaultT) return defaultT;
+	throw new TypeError(`Could not find ${defaultLocale}`);
+});
+
+/**
+ * Gets the value and the localizations from a language key.
+ * @param key The key to get the localizations from.
+ * @returns The retrieved data.
+ * @remarks This should be called **strictly** after loading the locales.
+ */
+export function getLocalizedData(key: TFunctionKeys): LocalizedData {
+	const locales = getLocales();
+	const defaultT = getDefaultT();
+
+	return {
+		value: defaultT(key),
+		localizations: Object.fromEntries(Array.from(locales, ([locale, t]) => [locale, t(key)]))
+	};
+}
+
+/**
+ * Applies the localized names on the builder, calling `setName` and `setNameLocalizations`.
+ * @param builder The builder to apply the localizations to.
+ * @param key The key to get the localizations from.
+ * @returns The updated builder.
+ */
+export function applyNameLocalizedBuilder<T extends BuilderWithName>(builder: T, key: TFunctionKeys) {
+	const result = getLocalizedData(key);
+	return builder.setName(result.value).setNameLocalizations(result.localizations);
+}
+
+/**
+ * Applies the localized descriptions on the builder, calling `setDescription` and `setDescriptionLocalizations`.
+ * @param builder The builder to apply the localizations to.
+ * @param key The key to get the localizations from.
+ * @returns The updated builder.
+ */
+export function applyDescriptionLocalizedBuilder<T extends BuilderWithDescription>(builder: T, key: TFunctionKeys) {
+	const result = getLocalizedData(key);
+	return builder.setDescription(result.value).setDescriptionLocalizations(result.localizations);
+}
+
+/**
+ * Applies the localized names and descriptions on the builder, calling {@link applyNameLocalizedBuilder} and
+ * {@link applyDescriptionLocalizedBuilder}.
+ * @param builder The builder to apply the localizations to.
+ * @param params The root key or the key for the name and description keys.
+ * @returns The updated builder.
+ * @remarks If only 2 parameters were passed, `name` will be defined as `${root}Name` and `description` as
+ * `${root}Description`, being `root` the second parameter in the function, after `builder`.
+ */
+export function applyLocalizedBuilder<T extends BuilderWithNameAndDescription>(
+	builder: T,
+	...params: [root: string] | [name: TFunctionKeys, description: TFunctionKeys]
+): T {
+	const [localeName, localeDescription] =
+		params.length === 1 ? [`${params[0]}Name` as TFunctionKeys, `${params[0]}Description` as TFunctionKeys] : params;
+
+	applyNameLocalizedBuilder(builder, localeName);
+	applyDescriptionLocalizedBuilder(builder, localeDescription);
+	return builder;
+}
+
+export function createSelectMenuChoiceName<V extends NonNullObject>(key: TFunctionKeys, value?: V): createSelectMenuChoiceName.Result<V> {
+	const result = getLocalizedData(key);
+	return {
+		...value,
+		name: result.value,
+		name_localizations: result.localizations
+	} as createSelectMenuChoiceName.Result<V>;
+}
+
+export namespace createSelectMenuChoiceName {
+	export type Result<V> = V & {
+		name: string;
+		name_localizations: LocalizationMap;
+	};
 }

--- a/packages/i18next/src/lib/types.ts
+++ b/packages/i18next/src/lib/types.ts
@@ -1,6 +1,7 @@
 import type { Awaitable } from '@sapphire/utilities';
 import type { Backend } from '@skyra/i18next-backend';
 import type { WatchOptions } from 'chokidar';
+import type { LocalizationMap } from 'discord-api-types/v10';
 import type {
 	BaseCommandInteraction,
 	Guild,
@@ -150,5 +151,21 @@ export interface I18nextFormatters {
 	format(value: any, lng: string | undefined, options: any): string;
 }
 
+export interface LocalizedData {
+	value: string;
+	localizations: LocalizationMap;
+}
+
+export interface BuilderWithName {
+	setName(name: string): this;
+	setNameLocalizations(localizedNames: LocalizationMap | null): this;
+}
+
+export interface BuilderWithDescription {
+	setDescription(description: string): this;
+	setDescriptionLocalizations(localizedDescriptions: LocalizationMap | null): this;
+}
+
+export type BuilderWithNameAndDescription = BuilderWithName & BuilderWithDescription;
 export type ChannelTarget = Message | DiscordChannel;
 export type Target = BaseCommandInteraction | ChannelTarget | Guild | MessageComponentInteraction;


### PR DESCRIPTION
This PR ports applyLocalizedBuilder from @skyra/http-framework-i18n

I did also consider having a resolveLocale function which would convert locales like "ja-JP" to ones assignable to type LocaleString. (https://github.com/Arcadia148/plugins/blob/feat/localizedBuilders2/packages/i18next/src/lib/functions.ts#L189)

This PR closes #353 