### PR TITLE
docs: add version for bullmq

### DIFF
--- a/packages/scheduled-tasks/README.md
+++ b/packages/scheduled-tasks/README.md
@@ -40,7 +40,7 @@ In case you want to use sqs as your provider:
 You can use the following command to install this package along with `bullmq`, or replace `npm install` with your package manager of choice.
 
 ```sh
-npm install @sapphire/plugin-scheduled-tasks @sapphire/framework bullmq
+npm install @sapphire/plugin-scheduled-tasks @sapphire/framework bullmq@^2.4.0
 ```
 
 or with `sqs`


### PR DESCRIPTION
The latest version of bullmq (3.0.0) will not work with scheduled tasks that use cron.

```
node_modules\.pnpm\cron-parser@4.6.0\node_modules\cron-parser\lib\expression.js:169
          throw new Error('Validation error, cannot resolve alias "' + match + '"');
                ^

Error: Validation error, cannot resolve alias "und"
    at node_modules\.pnpm\cron-parser@4.6.0\node_modules\cron-parser\lib\expression.js:169:17
    at String.replace (<anonymous>)
    at Function._parseField (node_modules\.pnpm\cron-parser@4.6.0\node_modules\cron-parser\lib\expression.js:163:21)       
    at parse (node_modules\.pnpm\cron-parser@4.6.0\node_modules\cron-parser\lib\expression.js:868:36)
```

Downgrading to version 2.4.0 fixed the issue.