### PR TITLE
refactor(scheduled-tasks)!: support for bullmq v3

### DIFF
--- a/packages/scheduled-tasks/README.md
+++ b/packages/scheduled-tasks/README.md
@@ -160,20 +160,20 @@ declare module '@sapphire/plugin-scheduled-tasks' {
 container.tasks.create('manual', payload, 5000);
 ```
 
-#### Cron Task Example
+#### Pattern Task Example
 
-Cron jobs are currently only supported by the Redis strategy.
+Pattern jobs are currently only supported by the Redis strategy.
 
 ##### Creating the Piece:
 
 ```typescript
 import { ScheduledTask } from '@sapphire/plugin-scheduled-tasks';
 
-export class CronTask extends ScheduledTask {
+export class PatternTask extends ScheduledTask {
 	public constructor(context: ScheduledTask.Context, options: ScheduledTask.Options) {
 		super(context, {
 			...options,
-			cron: '0 * * * *'
+			pattern: '0 * * * *'
 		});
 	}
 
@@ -184,14 +184,14 @@ export class CronTask extends ScheduledTask {
 
 declare module '@sapphire/plugin-scheduled-tasks' {
 	interface ScheduledTasks {
-		cron: never;
+		pattern: never;
 	}
 }
 ```
 
-##### Using Cron tasks
+##### Using Pattern tasks
 
-Cron & Interval tasks are loaded automatically.
+Pattern & Interval tasks are loaded automatically.
 
 #### Interval task example
 
@@ -222,7 +222,7 @@ declare module '@sapphire/plugin-scheduled-tasks' {
 
 ##### Using Interval tasks
 
-Cron & Interval tasks are loaded automatically.
+Pattern & Interval tasks are loaded automatically.
 
 ## Buy us some doughnuts
 

--- a/packages/scheduled-tasks/package.json
+++ b/packages/scheduled-tasks/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^1.8.8",
-		"bullmq": "^2.3.2",
+		"bullmq": "^3.0.0",
 		"gen-esm-wrapper": "^1.1.3",
 		"sqs-consumer": "^5.7.0",
 		"sqs-producer": "^2.1.0",

--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -44,7 +44,7 @@ export class ScheduledTaskHandler {
 								bullJobsOptions: piece.bullJobsOptions
 						  }
 						: {
-								cron: piece.cron!,
+								pattern: piece.pattern!,
 								bullJobsOptions: piece.bullJobsOptions
 						  })
 				}

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskRedisStrategy.ts
@@ -71,7 +71,7 @@ export class ScheduledTaskRedisStrategy implements ScheduledTaskBaseStrategy {
 							every: options.interval!
 					  }
 					: {
-							cron: options.cron!
+							pattern: options.pattern!
 					  }
 			};
 		}

--- a/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
+++ b/packages/scheduled-tasks/src/lib/strategies/ScheduledTaskSQSStrategy.ts
@@ -45,8 +45,8 @@ export class ScheduledTaskSQSStrategy implements ScheduledTaskBaseStrategy {
 	}
 
 	public create(task: string, payload?: unknown, options?: ScheduledTasksTaskOptions): Promise<SendMessageBatchResultEntryList> {
-		if (options?.cron) {
-			throw new Error('SQS does not support cron notation.');
+		if (options?.pattern) {
+			throw new Error('SQS does not support pattern notation.');
 		}
 
 		let delay = (options?.delay ?? 0) / 1000;

--- a/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
+++ b/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
@@ -3,13 +3,13 @@ import type { Awaitable } from '@sapphire/utilities';
 
 export abstract class ScheduledTask extends Piece {
 	public readonly interval: number | null;
-	public readonly cron: string | null;
+	public readonly pattern: string | null;
 	public readonly bullJobsOptions?: unknown;
 
 	public constructor(context: Piece.Context, options: ScheduledTaskOptions) {
 		super(context, options);
 		this.interval = options.interval ?? null;
-		this.cron = options.cron ?? null;
+		this.pattern = options.pattern ?? null;
 
 		// @ts-expect-error For redis strategy this property will actually be defined
 		this.bullJobsOptions = options.bullJobsOptions;
@@ -20,7 +20,7 @@ export abstract class ScheduledTask extends Piece {
 
 export interface ScheduledTaskOptions extends Piece.Options {
 	interval?: number | null;
-	cron?: string | null;
+	pattern?: string | null;
 }
 
 export namespace ScheduledTask {

--- a/packages/scheduled-tasks/src/lib/structures/ScheduledTaskStore.ts
+++ b/packages/scheduled-tasks/src/lib/structures/ScheduledTaskStore.ts
@@ -9,7 +9,7 @@ export class ScheduledTaskStore extends Store<ScheduledTask> {
 	}
 
 	public set(key: string, value: ScheduledTask): this {
-		if (value.interval !== null || value.cron !== null) {
+		if (value.interval !== null || value.pattern !== null) {
 			this.repeatedTasks.push(value);
 		}
 

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTasksTaskOptions.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTasksTaskOptions.ts
@@ -1,7 +1,7 @@
 export type ScheduledTasksTaskOptions = {
 	repeated: boolean;
 } & (
-	| { delay: number; interval?: never; cron?: never; customJobOptions?: any }
-	| { delay?: never; interval: number; cron?: never; customJobOptions?: any }
-	| { delay?: never; interval?: never; cron: string; customJobOptions?: any }
+	| { delay: number; interval?: never; pattern?: never; customJobOptions?: any }
+	| { delay?: never; interval: number; pattern?: never; customJobOptions?: any }
+	| { delay?: never; interval?: never; pattern: string; customJobOptions?: any }
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,7 +742,7 @@ __metadata:
     "@favware/cliff-jumper": ^1.8.8
     "@sapphire/stopwatch": ^1.5.0
     "@sapphire/utilities": ^3.11.0
-    bullmq: ^2.3.2
+    bullmq: ^3.0.0
     gen-esm-wrapper: ^1.1.3
     sqs-consumer: ^5.7.0
     sqs-producer: ^2.1.0
@@ -1502,9 +1502,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bullmq@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "bullmq@npm:2.3.2"
+"bullmq@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bullmq@npm:3.0.0"
   dependencies:
     cron-parser: ^4.6.0
     glob: ^8.0.3
@@ -1514,7 +1514,7 @@ __metadata:
     semver: ^7.3.7
     tslib: ^2.0.0
     uuid: ^9.0.0
-  checksum: 2a5560a4624e72cad60620de5441eb3549498ad18595c3d9950c3245827462c14ef4d537a6cc900c0ed102c27f8bbe7d8a9e51a9ef8c739e813756e7c9ba9d9d
+  checksum: e94fbb830516a8aa648af3986ad7c85548dea0ef4f4d3c97a26210b46fb65a3ab082a6ff9959e563709c92c7a0d783ed35eea2e319b6e92b276ed209beffea8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #385 

Breaking change -
Cron option is removed, see - https://github.com/taskforcesh/bullmq/pull/1456

squash body:
```
BREAKING CHANGE: This plugin now depends on bullmq version 3.x. This means `cron` has been changed to `pattern`, see also https://github.com/taskforcesh/bullmq/pull/1456 and the full changelog https://github.com/taskforcesh/bullmq/blob/master/docs/gitbook/changelog.md#300-2022-10-25
```