### PR TITLE
feat(plugin-patterncommands): add command weight and allow to run another patternCommand if one was caught by a precondition

### DIFF
--- a/packages/pattern-commands/src/lib/structures/PatternCommand.ts
+++ b/packages/pattern-commands/src/lib/structures/PatternCommand.ts
@@ -3,10 +3,22 @@ import type { Awaitable, Message } from 'discord.js';
 
 export abstract class PatternCommand extends Command<Args, PatternCommand.Options> {
 	public readonly chance: number;
+	public readonly weight: number;
 	public readonly matchFullName: boolean;
 	public constructor(context: PatternCommand.Context, options: PatternCommand.Options) {
 		super(context, options);
 		this.chance = options.chance ?? 100;
+		if (options.weight) {
+			if (options.weight < 0) {
+				this.weight = 0;
+			} else if (options.weight > 10) {
+				this.weight = 10;
+			} else {
+				this.weight = options.weight;
+			}
+		} else {
+			this.weight = 5;
+		}
 		this.matchFullName = options.matchFullName ?? false;
 	}
 
@@ -23,6 +35,11 @@ export interface PatternCommandOptions extends MessageCommand.Options {
 	 * @default 100
 	 */
 	chance?: number;
+	/**
+	 * The matching weight of the command.
+	 * @default 5
+	 */
+	weight?: number;
 	/**
 	 * If true it will only trigger on full matches (for example, explore won't trigger lore)
 	 * Note: It will only change the behavior of the command's name and not for the command's aliasses

--- a/packages/pattern-commands/src/lib/utils/PatternCommandInterfaces.ts
+++ b/packages/pattern-commands/src/lib/utils/PatternCommandInterfaces.ts
@@ -1,6 +1,11 @@
 import type { Message } from 'discord.js';
 import type { PatternCommand } from '../structures/PatternCommand';
 
+export interface PatternCommandPrePayload {
+	message: Message;
+	possibleCommands: PossiblePatternCommand[];
+}
+
 export interface PatternCommandPayload {
 	/** The message that triggered this PatternCommand */
 	message: Message;
@@ -32,3 +37,11 @@ export interface PatternCommandFinishedPayload extends PatternCommandAcceptedPay
 }
 
 export interface PatternCommandErrorPayload extends PatternCommandFinishedPayload {}
+
+export interface PatternCommandNoLuckPayload extends PatternCommandAcceptedPayload {}
+
+export interface PossiblePatternCommand {
+	command: PatternCommand;
+	alias: string;
+	weight: number;
+}

--- a/packages/pattern-commands/src/listeners/PluginCommandAccepted.ts
+++ b/packages/pattern-commands/src/listeners/PluginCommandAccepted.ts
@@ -10,16 +10,6 @@ export class CommandAcceptedListener extends Listener<typeof PatternCommandEvent
 	}
 
 	public async run(payload: PatternCommandAcceptedPayload) {
-		const { message, command, alias } = payload;
-
-		if (command.chance >= Math.round(Math.random() * 99) + 1) {
-			await this.runPatternCommand(payload);
-		} else {
-			message.client.emit(PatternCommandEvents.CommandNoLuck, message, command, alias);
-		}
-	}
-
-	public async runPatternCommand(payload: PatternCommandAcceptedPayload) {
 		const { message, command } = payload;
 
 		const result = await Result.fromAsync(async () => {
@@ -34,7 +24,7 @@ export class CommandAcceptedListener extends Listener<typeof PatternCommandEvent
 			return duration;
 		});
 
-		result.inspectErr((error) => message.client.emit(PatternCommandEvents.CommandError, error, { ...payload, duration: -1 }));
+		result.inspectErr((error) => message.client.emit(PatternCommandEvents.CommandError, error, { ...payload, error, duration: -1 }));
 
 		message.client.emit(PatternCommandEvents.CommandFinished, message, command, {
 			...payload,

--- a/packages/pattern-commands/src/listeners/PluginCommandAccepted.ts
+++ b/packages/pattern-commands/src/listeners/PluginCommandAccepted.ts
@@ -24,7 +24,7 @@ export class CommandAcceptedListener extends Listener<typeof PatternCommandEvent
 			return duration;
 		});
 
-		result.inspectErr((error) => message.client.emit(PatternCommandEvents.CommandError, error, { ...payload, error, duration: -1 }));
+		result.inspectErr((error) => message.client.emit(PatternCommandEvents.CommandError, error, { ...payload, duration: -1 }));
 
 		message.client.emit(PatternCommandEvents.CommandFinished, message, command, {
 			...payload,

--- a/packages/pattern-commands/src/listeners/PluginPreCommandRun.ts
+++ b/packages/pattern-commands/src/listeners/PluginPreCommandRun.ts
@@ -1,35 +1,49 @@
 import { Listener, type PreconditionStore } from '@sapphire/framework';
 import type { PieceContext } from '@sapphire/pieces';
 import { PatternCommandEvents } from '../lib/utils/PaternCommandEvents';
-import type { PatternPreCommandRunPayload } from '../lib/utils/PatternCommandInterfaces';
+import type { PatternCommandPayload, PatternCommandPrePayload } from '../lib/utils/PatternCommandInterfaces';
 
 export class PreCommandRunListener extends Listener<typeof PatternCommandEvents.PreCommandRun> {
 	public constructor(context: PieceContext) {
 		super(context, { event: PatternCommandEvents.PreCommandRun });
 	}
 
-	public async run(payload: PatternPreCommandRunPayload) {
-		const { message, command } = payload;
+	public async run(payload: PatternCommandPrePayload) {
+		const { message, possibleCommands } = payload;
 
-		// Run global preconditions:
-		const globalResult = await (this.container.stores.get('preconditions') as unknown as PreconditionStore).messageRun(
-			message,
-			command,
-			payload as any
-		);
+		for (const possibleCommand of possibleCommands) {
+			const { command } = possibleCommand;
+			const commandPayload: PatternCommandPayload = {
+				message,
+				command,
+				alias: possibleCommand.alias
+			};
 
-		if (globalResult.isErr()) {
-			message.client.emit(PatternCommandEvents.CommandDenied, globalResult.unwrapErr(), payload);
-			return;
+			// Run global preconditions:
+			const globalResult = await (this.container.stores.get('preconditions') as unknown as PreconditionStore).messageRun(
+				message,
+				command,
+				commandPayload as any
+			);
+
+			if (globalResult.isErr()) {
+				message.client.emit(PatternCommandEvents.CommandDenied, globalResult.unwrapErr(), commandPayload);
+				continue;
+			}
+
+			// Run command-specific preconditions:
+			const localResult = await command.preconditions.messageRun(message, command, payload as any);
+			if (localResult.isErr()) {
+				message.client.emit(PatternCommandEvents.CommandDenied, localResult.unwrapErr(), commandPayload);
+				continue;
+			}
+
+			if (command.chance >= Math.round(Math.random() * 99) + 1) {
+				message.client.emit(PatternCommandEvents.CommandAccepted, commandPayload);
+				break;
+			} else {
+				message.client.emit(PatternCommandEvents.CommandNoLuck, commandPayload);
+			}
 		}
-
-		// Run command-specific preconditions:
-		const localResult = await command.preconditions.messageRun(message, command, payload as any);
-		if (localResult.isErr()) {
-			message.client.emit(PatternCommandEvents.CommandDenied, localResult.unwrapErr(), payload);
-			return;
-		}
-
-		message.client.emit(PatternCommandEvents.CommandAccepted, payload);
 	}
 }


### PR DESCRIPTION
With this feature users can add a weight to the `patternCommand` which can influence which one should run if more than one is found in the given message.

For example if `message.content` is "Split up and search for clues" and there's a `patternCommand-search` with the weight of 3 and `patternCommand-clue` with weight of 7, the `patternCommand-clue` will run

BUT if the preconditions doesn't allow `patternCommand-clue` to run, `patternCommand-search` will run instead (if the preconditions are allowing it) 