### PR TITLE
fix: supportsXCommands() methods now use SubcommandMappings

### DIFF
--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -116,6 +116,14 @@ export class Subcommand<PreParseReturn extends Args = Args, O extends Subcommand
 		}
 	}
 
+	public override supportsMessageCommands(): boolean {
+		return this.#supportsCommandType('messageRun');
+	}
+
+	public override supportsChatInputCommands(): this is ChatInputCommand {
+		return this.#supportsCommandType('chatInputRun');
+	}
+
 	public async messageRun(message: Message, args: PreParseReturn, context: MessageCommand.RunContext) {
 		args.save();
 		const subcommandOrGroup = args.nextMaybe();
@@ -344,6 +352,15 @@ export class Subcommand<PreParseReturn extends Args = Args, O extends Subcommand
 		}
 
 		return { mapping: foundDefault, defaultMatch: true } as const;
+	}
+
+	#supportsCommandType(commandType: 'messageRun' | 'chatInputRun'): boolean {
+		return this.parsedSubcommandMappings.some((mapping) => {
+			if (mapping.type === 'group') {
+				return mapping.entries.some((groupCommand) => Reflect.has(groupCommand, commandType));
+			}
+			return Reflect.has(mapping, commandType);
+		});
 	}
 }
 


### PR DESCRIPTION
This PR changes the behavior of the `supportsMessageCommands()` and `supportsChatInputCommands()` methods on the subcommand class. Previously, these both would always return true since the methods inherited from the `Command` class just check for the existence of a `messageRun()` or `chatInputRun()` method. Since both methods are implemented on the `Subcommand` class, the type guards would always return true. This PR instead determines the output of these methods by checking if a `messageRun` or  `chatInputRun` property was provided on any of the subcommands in the `parsedSubcommandMappings` array. These changes were tested using commands with all combinations of having a messageRun, having a chatInputRun, having both, having groups, and not having groups. Test commands can be found [in this gist](https://gist.github.com/BenSegal855/5d01722ae37bbac6430e0d420081ac6a).