### PR TITLE
fix: remove const enum for verbatimModuleSyntax

### DIFF
--- a/packages/api/src/lib/structures/http/HttpCodes.ts
+++ b/packages/api/src/lib/structures/http/HttpCodes.ts
@@ -1,4 +1,4 @@
-export const enum HttpCodes {
+export enum HttpCodes {
 	/**
 	 * Standard response for successful HTTP requests. The actual response will
 	 * depend on the request method used. In a GET request, the response will

--- a/packages/api/src/lib/structures/http/Server.ts
+++ b/packages/api/src/lib/structures/http/Server.ts
@@ -9,7 +9,7 @@ import { ApiRequest } from '../api/ApiRequest';
 import { ApiResponse } from '../api/ApiResponse';
 import { Auth, type ServerOptionsAuth } from './Auth';
 
-export const enum ServerEvents {
+export enum ServerEvents {
 	Error = 'error',
 	Request = 'request',
 	Match = 'match',

--- a/packages/api/src/lib/utils/MimeTypes.ts
+++ b/packages/api/src/lib/utils/MimeTypes.ts
@@ -1,4 +1,4 @@
-export const enum MimeTypes {
+export enum MimeTypes {
 	ApplicationFormUrlEncoded = 'application/x-www-form-urlencoded',
 	ApplicationJson = 'application/json',
 	AudioOgg = 'audio/ogg',

--- a/packages/api/src/lib/utils/RouteData.ts
+++ b/packages/api/src/lib/utils/RouteData.ts
@@ -3,7 +3,7 @@ const [slash, colon]: [number, number] = [47, 58];
 /**
  * @since 1.0.0
  */
-export const enum TypeState {
+export enum TypeState {
 	/**
 	 * @since 1.0.0
 	 */

--- a/packages/logger/src/lib/LoggerStyle.ts
+++ b/packages/logger/src/lib/LoggerStyle.ts
@@ -69,7 +69,7 @@ export type LoggerStyleResolvable = Colorette.Color | LoggerStyleOptions;
  * The text styles.
  * @since 1.0.0
  */
-export const enum LoggerStyleEffect {
+export enum LoggerStyleEffect {
 	Reset = 'reset',
 	Bold = 'bold',
 	Dim = 'dim',
@@ -84,7 +84,7 @@ export const enum LoggerStyleEffect {
  * The text colors.
  * @since 1.0.0
  */
-export const enum LoggerStyleText {
+export enum LoggerStyleText {
 	Black = 'black',
 	Red = 'red',
 	Green = 'green',
@@ -108,7 +108,7 @@ export const enum LoggerStyleText {
  * The background colors.
  * @since 1.0.0
  */
-export const enum LoggerStyleBackground {
+export enum LoggerStyleBackground {
 	Black = 'bgBlack',
 	Red = 'bgRed',
 	Green = 'bgGreen',


### PR DESCRIPTION
`const enum` is not available when option `verbatimModuleSyntax` is enabled in TS 5.x.
By removing `const`, it makes enum available in TS 5.x with `verbatimModuleSyntax`.
