### PR TITLE
feat(scheduled-tasks): add typings for listener events

### DIFF
--- a/packages/scheduled-tasks/src/lib/types/ScheduledTaskEvents.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTaskEvents.ts
@@ -2,39 +2,59 @@
  * Events emitted during the process setting up the scheduler and running a task.
  * You can use these events to trace the progress for debugging purposes.
  */
-export enum ScheduledTaskEvents {
-	/** Event that is emitted if a task piece is not found in the store
-	 * @param task The name of the task what tried to run
-	 * @param payload The payload of the task
+export const ScheduledTaskEvents = {
+	/**
+	 * Event that is emitted if a task piece is not found in the store
 	 */
-	ScheduledTaskNotFound = 'scheduledTaskNotFound',
-	/** Event that is emitted before a task's "run" method is called
-	 * @param task The name of the task what tried to run
-	 * @param payload The payload of the task
+	ScheduledTaskNotFound: 'scheduledTaskNotFound' as const,
+	/**
+	 * Event that is emitted before a task's "run" method is called
 	 */
-	ScheduledTaskRun = 'scheduledTaskRun',
-	/** Event that is emitted when a task's "run" method throws an error
-	 * @param error The error what occurred during the run
-	 * @param task The name of the task what tried to run
-	 * @param duration The duration what indicates how long running the task took
-	 * @param payload The payload of the task
+	ScheduledTaskRun: 'scheduledTaskRun' as const,
+	/**
+	 * Event that is emitted when a task's "run" method throws an error
 	 */
-	ScheduledTaskError = 'scheduledTaskError',
-	/** Event that is emitted when a tasks's "run" method is successful
-	 * @param task The name of the task what tried to run
-	 * @param payload The payload of the task
-	 * @param result The result of the run
-	 * @param duration The duration what indicates how long running the task took
+	ScheduledTaskError: 'scheduledTaskError' as const,
+	/**
+	 * Event that is emitted when a tasks's "run" method is successful
 	 */
-	ScheduledTaskSuccess = 'scheduledTaskSuccess',
-	/** Event that is emitted when a task's "run" method finishes, regardless of whether an error occurred or not
-	 * @param task The name of the task what tried to run
-	 * @param duration The duration what indicates how long running the task took
-	 * @param payload The payload of the task
+	ScheduledTaskSuccess: 'scheduledTaskSuccess' as const,
+	/**
+	 * Event that is emitted when a task's "run" method finishes, regardless of whether an error occurred or not
 	 */
-	ScheduledTaskFinished = 'scheduledTaskFinished',
-	/** Event that is emitted when the scheduler fails to connect to the server (i.e. redis or sqs)
-	 * @param error The error occurred the connection
+	ScheduledTaskFinished: 'scheduledTaskFinished' as const,
+	/**
+	 * Event that is emitted when the scheduler fails to connect to the server (i.e. redis)
 	 */
-	ScheduledTaskStrategyConnectError = 'scheduledTaskStrategyConnectError'
+	ScheduledTaskStrategyConnectError: 'scheduledTaskStrategyConnectError' as const
+};
+
+declare module 'discord.js' {
+	interface ClientEvents {
+		[ScheduledTaskEvents.ScheduledTaskNotFound]: [
+			task: string, //
+			payload: unknown
+		];
+		[ScheduledTaskEvents.ScheduledTaskRun]: [
+			task: string, //
+			payload: unknown
+		];
+		[ScheduledTaskEvents.ScheduledTaskError]: [
+			error: unknown, //
+			task: string,
+			payload: unknown
+		];
+		[ScheduledTaskEvents.ScheduledTaskSuccess]: [
+			task: string, //
+			payload: unknown,
+			result: unknown,
+			duration: number
+		];
+		[ScheduledTaskEvents.ScheduledTaskFinished]: [
+			task: string, //
+			duration: number | null,
+			payload: unknown
+		];
+		[ScheduledTaskEvents.ScheduledTaskStrategyConnectError]: [error: unknown];
+	}
 }


### PR DESCRIPTION
Types for events were previously just comments on the `ScheduledTaskEvents` enum. Now the types can be properly enforced for emitters and listeners.