### PR TITLE
feat(api): add `text/html` and `image/x-icon` mime types

### DIFF
--- a/packages/api/src/lib/structures/api/ApiResponse.ts
+++ b/packages/api/src/lib/structures/api/ApiResponse.ts
@@ -112,6 +112,13 @@ export class ApiResponse<Request extends IncomingMessage = IncomingMessage> exte
 	}
 
 	/**
+	 * @since 5.1.0
+	 */
+	public html(code: number, data: string): void {
+		this.setContentType(MimeTypes.TextHtml).status(code).end(data);
+	}
+
+	/**
 	 * @since 1.0.0
 	 */
 	public setContentType(contentType: MimeTypes): this {

--- a/packages/api/src/lib/utils/MimeTypes.ts
+++ b/packages/api/src/lib/utils/MimeTypes.ts
@@ -8,6 +8,7 @@ export enum MimeTypes {
 	ImageJpg = 'image/jpeg',
 	ImagePng = 'image/png',
 	ImageWebp = 'image/webp',
+	ImageXIcon = 'image/x-icon',
 	TextPlain = 'text/plain',
 	TextHtml = 'text/html',
 	VideoMp4 = 'video/mp4',

--- a/packages/api/src/lib/utils/MimeTypes.ts
+++ b/packages/api/src/lib/utils/MimeTypes.ts
@@ -9,6 +9,7 @@ export enum MimeTypes {
 	ImagePng = 'image/png',
 	ImageWebp = 'image/webp',
 	TextPlain = 'text/plain',
+	TextHtml = 'text/html',
 	VideoMp4 = 'video/mp4',
 	VideoMpeg = 'video/mpeg',
 	VideoOgg = 'video/ogg',


### PR DESCRIPTION
I added the `text/html` mimetype, so that it is now possible to send html in api routes. This is also used in the new `ApiResponse.html()` function which is a shortcut similar to `ApiResponse.json()` and `ApiResponse.text()`.

I also added the `image/x-icon` mimetype in order to implement an endpoint for favicon.ico :)

Another idea would be to make the favicon a configuration option (providing a buffer / image path?), so that we don't have to manually create a route for it. But that's just inspiration, I'm not sure how many people would want to use it / if you want that in the options :)