### PR TITLE
refactor: generalize `stdout` and `stderr` types

### DIFF
--- a/packages/logger/src/lib/Logger.ts
+++ b/packages/logger/src/lib/Logger.ts
@@ -106,18 +106,18 @@ export class Logger extends BuiltinLogger {
  */
 export interface LoggerOptions {
 	/**
-	 * The WriteStream for the output logs.
+	 * A writable stream for the output logs.
 	 * @since 1.0.0
 	 * @default process.stdout
 	 */
-	stdout?: NodeJS.WriteStream;
+	stdout?: NodeJS.WritableStream;
 
 	/**
-	 * A WriteStream for the error logs.
+	 * A writable stream for the error logs.
 	 * @since 1.0.0
 	 * @default process.stderr
 	 */
-	stderr?: NodeJS.WriteStream;
+	stderr?: NodeJS.WritableStream;
 
 	/**
 	 * The default options used to fill all the possible values for {@link LoggerOptions.format}.


### PR DESCRIPTION
`process.stdout` and `process.stderr` are both `WriteStream`, which has the following inheritance:

- `NodeJS.WriteStream` extends `tty.WriteStream`
- `tty.WriteStream` extends `net.Socket`
- `net.Socket` extends `stream.Duplex`
- `stream.Duplex` extends `stream.Readable` implements `stream.Writable`
- `stream.Writable` extends `Stream` implements `NodeJS.WritableStream`

*Not a breaking change, yay!* 🎉

This commit generalizes the `stdout` and `stderr` types to `NodeJS.WritableStream` to allow for more flexibility and match the types in `Console`'s constructor arguments.

I don't know why `NodeJS.WriteStream`, being such a generic name, has such a deep inheritance that extends `Duplex`, which is also readable, but here we are. `NodeJS.WritableStream` is the most generic type that can be used for both `stdout` and `stderr`.
