### PR TITLE
refactor(*): cleanup plugin registry files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 node_modules/
-**/dist/**/*.js
-**/docs/**/*.js
-**/build/**/*.js
+**/dist/**/*
+**/docs/**/*
+**/build/**/*
 **/*.d.ts

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,20 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/api",
 	"scripts": {
@@ -49,8 +48,7 @@
 	},
 	"files": [
 		"dist/",
-		"!dist/.tsbuildinfo",
-		"./register.*"
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=v14.0.0",

--- a/packages/api/register.d.ts
+++ b/packages/api/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/api/register.js
+++ b/packages/api/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/api/register.mjs
+++ b/packages/api/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/packages/editable-commands/package.json
+++ b/packages/editable-commands/package.json
@@ -9,20 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/editable-commands",
 	"scripts": {
@@ -45,10 +44,8 @@
 		"directory": "packages/editable-commands"
 	},
 	"files": [
-		"dist/**/*.js*",
-		"dist/**/*.mjs*",
-		"dist/**/*.d*",
-		"./register.*"
+		"dist/",
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=16.6.0",

--- a/packages/editable-commands/register.d.ts
+++ b/packages/editable-commands/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/editable-commands/register.js
+++ b/packages/editable-commands/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/editable-commands/register.mjs
+++ b/packages/editable-commands/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -9,20 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://sapphirejs.dev",
 	"scripts": {
@@ -45,10 +44,8 @@
 		"directory": "packages/hmr"
 	},
 	"files": [
-		"dist/**/*.js*",
-		"dist/**/*.mjs*",
-		"dist/**/*.d*",
-		"./register.*"
+		"dist/",
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=16.6.0",

--- a/packages/hmr/register.d.ts
+++ b/packages/hmr/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/hmr/register.js
+++ b/packages/hmr/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/hmr/register.mjs
+++ b/packages/hmr/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/packages/i18next/package.json
+++ b/packages/i18next/package.json
@@ -9,21 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./dist/register.mjs",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/i18next",
 	"scripts": {
@@ -50,10 +48,8 @@
 		"directory": "packages/i18next"
 	},
 	"files": [
-		"dist/**/*.js*",
-		"dist/**/*.mjs*",
-		"dist/**/*.d*",
-		"./register.*"
+		"dist/",
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=v14",

--- a/packages/i18next/register.d.ts
+++ b/packages/i18next/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/i18next/register.js
+++ b/packages/i18next/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/i18next/register.mjs
+++ b/packages/i18next/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -9,20 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/logger",
 	"scripts": {
@@ -47,10 +46,8 @@
 		"directory": "packages/logger"
 	},
 	"files": [
-		"dist/**/*.js*",
-		"dist/**/*.mjs*",
-		"dist/**/*.d*",
-		"./register.*"
+		"dist/",
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=v14.0.0",

--- a/packages/logger/register.d.ts
+++ b/packages/logger/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/logger/register.js
+++ b/packages/logger/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/logger/register.mjs
+++ b/packages/logger/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/packages/pattern-commands/package.json
+++ b/packages/pattern-commands/package.json
@@ -9,20 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/pattern-commands",
 	"scripts": {
@@ -44,10 +43,8 @@
 		"directory": "packages/pattern-commands"
 	},
 	"files": [
-		"dist/**/*.js*",
-		"dist/**/*.mjs*",
-		"dist/**/*.d*",
-		"./register.*"
+		"dist/",
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=v14.0.0",

--- a/packages/pattern-commands/register.d.ts
+++ b/packages/pattern-commands/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/pattern-commands/register.js
+++ b/packages/pattern-commands/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/pattern-commands/register.mjs
+++ b/packages/pattern-commands/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/packages/scheduled-tasks/package.json
+++ b/packages/scheduled-tasks/package.json
@@ -9,20 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/scheduled-tasks",
 	"scripts": {
@@ -55,8 +54,7 @@
 	},
 	"files": [
 		"dist/",
-		"!dist/.tsbuildinfo",
-		"./register.*"
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=v14.18.0",

--- a/packages/scheduled-tasks/register.d.ts
+++ b/packages/scheduled-tasks/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/scheduled-tasks/register.js
+++ b/packages/scheduled-tasks/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/scheduled-tasks/register.mjs
+++ b/packages/scheduled-tasks/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/packages/subcommands/package.json
+++ b/packages/subcommands/package.json
@@ -9,20 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/subcommands",
 	"scripts": {
@@ -45,10 +44,8 @@
 		"directory": "packages/subcommands"
 	},
 	"files": [
-		"dist/**/*.js*",
-		"dist/**/*.mjs*",
-		"dist/**/*.d*",
-		"./register.*"
+		"dist/",
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=v14.0.0",

--- a/packages/subcommands/register.d.ts
+++ b/packages/subcommands/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/subcommands/register.js
+++ b/packages/subcommands/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/subcommands/register.mjs
+++ b/packages/subcommands/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/packages/utilities-store/package.json
+++ b/packages/utilities-store/package.json
@@ -9,20 +9,19 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.js"
 		},
 		"./register": {
-			"import": "./register.mjs",
-			"require": "./register.js",
-			"types": "./register.d.ts"
+			"types": "./dist/register.d.ts",
+			"import": "./dist/register.mjs",
+			"require": "./dist/register.js"
 		}
 	},
 	"sideEffects": [
 		"./dist/register.js",
-		"./register.js",
-		"./register.mjs"
+		"./dist/register.mjs"
 	],
 	"homepage": "https://github.com/sapphiredev/plugins/tree/main/packages/api",
 	"scripts": {
@@ -44,10 +43,8 @@
 		"directory": "packages/utilities-store"
 	},
 	"files": [
-		"dist/**/*.js*",
-		"dist/**/*.mjs*",
-		"dist/**/*.d*",
-		"./register.*"
+		"dist/",
+		"!dist/.tsbuildinfo"
 	],
 	"engines": {
 		"node": ">=v14.0.0",

--- a/packages/utilities-store/register.d.ts
+++ b/packages/utilities-store/register.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/register';

--- a/packages/utilities-store/register.js
+++ b/packages/utilities-store/register.js
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const tslib = require('tslib');
-
-tslib.__exportStar(require('./dist/register.js'), exports);

--- a/packages/utilities-store/register.mjs
+++ b/packages/utilities-store/register.mjs
@@ -1,1 +1,0 @@
-export * from './dist/register.mjs';

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -6,8 +6,6 @@
 		"packages/**/*.mjs",
 		"packages/**/vitest.config.ts",
 		"packages/**/tests/*.js",
-		"packages/**/register*.js",
-		"packages/**/register*.mjs",
 		"packages/**/types*.js",
 		"packages/**/types*.mjs",
 		"./vitest.config.ts"

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,13 +1,4 @@
 {
 	"extends": "./tsconfig.base.json",
-	"include": [
-		"scripts",
-		"packages/**/*.ts",
-		"packages/**/*.mjs",
-		"packages/**/vitest.config.ts",
-		"packages/**/tests/*.js",
-		"packages/**/types*.js",
-		"packages/**/types*.mjs",
-		"./vitest.config.ts"
-	]
+	"include": ["scripts", "packages/**/*.ts", "./vitest.config.ts"]
 }


### PR DESCRIPTION
I'm pretty sure we can do this. I'm pretty sure this is even supported with CJS with Node 18. Need to test though.