### PR TITLE
fix(i18next): move module augmentations to `index` and import in `register`

### DIFF
--- a/packages/i18next/src/index.ts
+++ b/packages/i18next/src/index.ts
@@ -1,4 +1,17 @@
+import type { InternationalizationHandler } from './lib/InternationalizationHandler';
+import type { InternationalizationClientOptions } from './lib/types';
+
 export type { TFunction, TOptions } from 'i18next';
 export * from './lib/InternationalizationHandler';
 export * from './lib/functions';
 export * from './lib/types';
+
+declare module '@sapphire/pieces' {
+	interface Container {
+		i18n: InternationalizationHandler;
+	}
+}
+
+declare module 'discord.js' {
+	export interface ClientOptions extends InternationalizationClientOptions {}
+}

--- a/packages/i18next/src/register.ts
+++ b/packages/i18next/src/register.ts
@@ -1,8 +1,8 @@
+import './index';
 import { Plugin, SapphireClient, container, postLogin, preGenericsInitialization, preLogin } from '@sapphire/framework';
 import { watch } from 'chokidar';
 import type { ClientOptions } from 'discord.js';
-
-import { InternationalizationHandler, type InternationalizationClientOptions } from './index';
+import { InternationalizationHandler } from './lib/InternationalizationHandler';
 
 export class I18nextPlugin extends Plugin {
 	public static [preGenericsInitialization](this: SapphireClient, options: ClientOptions): void {
@@ -26,13 +26,3 @@ export class I18nextPlugin extends Plugin {
 SapphireClient.plugins.registerPostInitializationHook(I18nextPlugin[preGenericsInitialization], 'I18next-PreGenericsInitialization');
 SapphireClient.plugins.registerPreLoginHook(I18nextPlugin[preLogin], 'I18next-PreLogin');
 SapphireClient.plugins.registerPostLoginHook(I18nextPlugin[postLogin], 'I18next-PostLogin');
-
-declare module '@sapphire/pieces' {
-	interface Container {
-		i18n: InternationalizationHandler;
-	}
-}
-
-declare module 'discord.js' {
-	export interface ClientOptions extends InternationalizationClientOptions {}
-}


### PR DESCRIPTION
Same as #471 but now pushing it through I guess for the sake of consistency with other plugins. That said, this won't fix the actual augmentation issues that #471 was supposedly meant to fix as those were and are still related to TS 5.2 in combination with @sapphire/ts-config v4 or not using
```json
"module": "node16",
"moduleResolution": "node16"
```