### PR TITLE
fix(i18next): fixed `resolveKey` using incorrect paramater when no default value is passed through

### DIFF
--- a/packages/i18next/src/lib/functions.ts
+++ b/packages/i18next/src/lib/functions.ts
@@ -103,7 +103,7 @@ export async function resolveKey<
 		return container.i18n.format<Key, TOpt, Ns, Ret, ActualOptions>(language, key, defaultValueOrOptions, optionsOrUndefined);
 	}
 
-	return container.i18n.format<Key, TOpt, Ns, Ret, ActualOptions>(language, key, undefined, optionsOrUndefined);
+	return container.i18n.format<Key, TOpt, Ns, Ret, ActualOptions>(language, key, undefined, defaultValueOrOptions);
 }
 
 /**


### PR DESCRIPTION
The value passed to the`resolveKey ` function was incorrect, resulting in errors every time it was called. 
![](https://cdn.discordapp.com/attachments/1149479137149464807/1149629639304675399/Capture_decran_2023-09-08_a_10.56.03.png)
This PR corrects this problem.