### PR TITLE
fix:(plugin-subcommands) :bug: fix typeof run functions

### DIFF
--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -10,7 +10,7 @@ import {
 	type MessageCommandDeniedPayload,
 	type PieceContext
 } from '@sapphire/framework';
-import { cast, deepClone } from '@sapphire/utilities';
+import { Awaitable, cast, deepClone } from '@sapphire/utilities';
 import type { CacheType, Message } from 'discord.js';
 import type {
 	ChatInputCommandSubcommandMappingMethod,
@@ -198,6 +198,7 @@ export class Subcommand<PreParseReturn extends Args = Args, O extends Subcommand
 	 *
 	 * **DO NOT** override this in your implementation of a subcommand!
 	 */
+	public override messageRun(message: Message, args: PreParseReturn, context: MessageCommand.RunContext): Awaitable<unknown>;
 	public override async messageRun(message: Message, args: PreParseReturn, context: MessageCommand.RunContext) {
 		args.save();
 		const subcommandOrGroup = args.nextMaybe();
@@ -295,6 +296,7 @@ export class Subcommand<PreParseReturn extends Args = Args, O extends Subcommand
 	 *
 	 * **DO NOT** override this in your implementation of a subcommand!
 	 */
+	public override chatInputRun(interaction: ChatInputCommand.Interaction, context: ChatInputCommand.RunContext): Awaitable<unknown>;
 	public override async chatInputRun(interaction: ChatInputCommand.Interaction, context: ChatInputCommand.RunContext) {
 		const subcommandName = interaction.options.getSubcommand(false);
 		const subcommandGroupName = interaction.options.getSubcommandGroup(false);


### PR DESCRIPTION
In some cases we create an abstract class of the Subcommand Class but we do not necessarily want to create subcommands so we use the usual method but if we return a response from the interaction it puts us an error like the one below while with the Command class it does not happen.

This PR therefore updates this case in order to avoid having a type error.
![](https://cdn.discordapp.com/attachments/1090586167218544641/1149658628421337138/Capture_decran_2023-09-08_a_12.52.46.png)
