### PR TITLE
Allow user to replace default logger from ClientOptions

### DIFF
--- a/packages/logger/src/register.ts
+++ b/packages/logger/src/register.ts
@@ -11,7 +11,7 @@ export class LoggerPlugin extends Plugin {
 	 */
 	public static [preGenericsInitialization](this: SapphireClient, options: ClientOptions): void {
 		options.logger ??= {};
-		options.logger.instance = new Logger(options.logger);
+		options.logger.instance ??= new Logger(options.logger);
 	}
 }
 


### PR DESCRIPTION
Because `LoggerPlugin` is always create a new instance of the logger, it's not possible to pass it from the `ShappireClient` using the `ClientOptions`