### PR TITLE
feat(scheduled-tasks): add error listeners

### DIFF
--- a/packages/scheduled-tasks/src/index.ts
+++ b/packages/scheduled-tasks/src/index.ts
@@ -21,5 +21,10 @@ declare module '@sapphire/pieces' {
 declare module 'discord.js' {
 	export interface ClientOptions {
 		tasks?: ScheduledTaskHandlerOptions;
+		/**
+		 * If the the pre-included scheduled task error listeners should be loaded
+		 * @default false
+		 */
+		loadScheduledTaskErrorListeners?: boolean;
 	}
 }

--- a/packages/scheduled-tasks/src/listeners/connectError.ts
+++ b/packages/scheduled-tasks/src/listeners/connectError.ts
@@ -1,0 +1,15 @@
+import { Listener } from '@sapphire/framework';
+import { ScheduledTaskEvents } from '../lib/types/ScheduledTaskEvents';
+
+export class PluginListener extends Listener<typeof ScheduledTaskEvents.ScheduledTaskStrategyConnectError> {
+	public constructor(context: Listener.Context) {
+		super(context, {
+			name: ScheduledTaskEvents.ScheduledTaskStrategyConnectError,
+			event: ScheduledTaskEvents.ScheduledTaskStrategyConnectError
+		});
+	}
+
+	public override run(error: unknown) {
+		this.container.logger.error(`[ScheduledTaskPlugin] Encountered an error when trying to connect to the Redis instance`, error);
+	}
+}

--- a/packages/scheduled-tasks/src/listeners/error.ts
+++ b/packages/scheduled-tasks/src/listeners/error.ts
@@ -1,0 +1,20 @@
+import { Listener } from '@sapphire/framework';
+import { ScheduledTaskEvents } from '../lib/types/ScheduledTaskEvents';
+
+export class PluginListener extends Listener<typeof ScheduledTaskEvents.ScheduledTaskError> {
+	public constructor(context: Listener.Context) {
+		super(context, {
+			name: ScheduledTaskEvents.ScheduledTaskError,
+			event: ScheduledTaskEvents.ScheduledTaskError
+		});
+	}
+
+	public override run(error: unknown, task: string) {
+		let message = `Encountered error on scheduled task "${task}"`;
+
+		const piece = this.container.stores.get('scheduled-tasks').get(task);
+		if (piece) message = message.concat(` at path "${piece.location.full}"`);
+
+		this.container.logger.error(message, error);
+	}
+}

--- a/packages/scheduled-tasks/src/listeners/notFound.ts
+++ b/packages/scheduled-tasks/src/listeners/notFound.ts
@@ -1,0 +1,15 @@
+import { Listener } from '@sapphire/framework';
+import { ScheduledTaskEvents } from '../lib/types/ScheduledTaskEvents';
+
+export class PluginListener extends Listener<typeof ScheduledTaskEvents.ScheduledTaskNotFound> {
+	public constructor(context: Listener.Context) {
+		super(context, {
+			name: ScheduledTaskEvents.ScheduledTaskNotFound,
+			event: ScheduledTaskEvents.ScheduledTaskNotFound
+		});
+	}
+
+	public override run(task: string) {
+		this.container.logger.error(`[ScheduledTaskPlugin] There was no task found for "${task}"`);
+	}
+}

--- a/packages/scheduled-tasks/src/register.ts
+++ b/packages/scheduled-tasks/src/register.ts
@@ -4,6 +4,7 @@ import { container, Plugin, postInitialization, postLogin, preGenericsInitializa
 import type { ClientOptions } from 'discord.js';
 import { ScheduledTaskHandler } from './lib/ScheduledTaskHandler';
 import { ScheduledTaskStore } from './lib/structures/ScheduledTaskStore';
+import { join } from 'node:path';
 
 /**
  * A plugin for scheduling tasks in a SapphireClient.
@@ -21,8 +22,12 @@ export class ScheduledTasksPlugin extends Plugin {
 	/**
 	 * @since 1.0.0
 	 */
-	public static [postInitialization](this: SapphireClient): void {
+	public static [postInitialization](this: SapphireClient, options: ClientOptions): void {
 		this.stores.register(new ScheduledTaskStore());
+
+		if (options.loadScheduledTaskErrorListeners === true) {
+			this.stores.get('listeners').registerPath(join(__dirname, 'listeners'));
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR adds default error listeners to the scheduled-tasks plugin. They are **not** enabled by default.

Currently if a connection error is thrown in the `ScheduledTaskHandler` constructor, it gets emitted to a listener instead of showing in stderr. So if there if no listener for that event an error will never be shown, which is not fun for debugging.

Reference: https://discord.com/channels/737141877803057244/737142940777971773/1170749988918272063