### PR TITLE
feat: re-export `i18next` instance

### DIFF
--- a/packages/i18next/src/index.ts
+++ b/packages/i18next/src/index.ts
@@ -1,7 +1,7 @@
 import type { InternationalizationHandler } from './lib/InternationalizationHandler';
 import type { InternationalizationClientOptions } from './lib/types';
 
-export type { TFunction, TOptions } from 'i18next';
+export { default as i18next, type TFunction, type TOptions } from 'i18next';
 export * from './lib/InternationalizationHandler';
 export * from './lib/functions';
 export * from './lib/types';


### PR DESCRIPTION
Re-exporting the `i18next` instance is particularly useful in some concrete cases, such as registering plugins of any kind or having access to many of the [`I18n`](https://www.i18next.com/overview/api)'s methods.

Doing `import i18next from 'i18next';` isn't a portable solution. Currently, if `@sapphire/plugin-i18next` is imported, it'll always use the CJS version of `i18next`[^1], as the library is built into CJS with ESM bindings[^2].

[^1]: https://github.com/i18next/i18next/blob/2a7e478b6b7635ebd5505261ae0064dcf41116b4/package.json#L15-L22
[^2]: https://github.com/sapphiredev/plugins/blob/95fe74c44ccae490710923cb4d25d45b13ff4030/packages/i18next/package.json#L30-L32
