### PR TITLE
feat(scheduled-tasks): add timezone for tasks with pattern

### DIFF
--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -65,7 +65,8 @@ export class ScheduledTaskHandler {
 							every: options.interval!
 						}
 					: {
-							pattern: options.pattern!
+							pattern: options.pattern!,
+							tz: options.timezone
 						}
 			};
 		}
@@ -87,6 +88,7 @@ export class ScheduledTaskHandler {
 						}
 					: {
 							pattern: piece.pattern!,
+							timezone: piece.timezone,
 							customJobOptions: piece.customJobOptions
 						})
 			}

--- a/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
+++ b/packages/scheduled-tasks/src/lib/structures/ScheduledTask.ts
@@ -9,6 +9,7 @@ import type { JobsOptions } from 'bullmq';
 export abstract class ScheduledTask<Options extends ScheduledTask.Options = ScheduledTask.Options> extends Piece<Options, 'scheduled-tasks'> {
 	public readonly interval: number | null;
 	public readonly pattern: string | null;
+	public readonly timezone: string;
 	public readonly customJobOptions?: ScheduledTaskCustomJobOptions;
 
 	public constructor(context: ScheduledTask.LoaderContext, options: ScheduledTaskOptions) {
@@ -16,6 +17,7 @@ export abstract class ScheduledTask<Options extends ScheduledTask.Options = Sche
 		this.interval = options.interval ?? null;
 		this.pattern = options.pattern ?? null;
 		this.customJobOptions = options.customJobOptions;
+		this.timezone = options.timezone ?? 'UTC';
 	}
 
 	public abstract run(payload: unknown): Awaitable<unknown>;
@@ -37,6 +39,12 @@ export interface ScheduledTaskOptions extends Piece.Options {
 	 * Custom options to pass to the job scheduler.
 	 */
 	customJobOptions?: ScheduledTaskCustomJobOptions;
+
+	/**
+	 * The timezone to use for the task.
+	 * @default 'UTC'
+	 */
+	timezone?: string | null;
 }
 
 /**

--- a/packages/scheduled-tasks/src/lib/types/ScheduledTaskTypes.ts
+++ b/packages/scheduled-tasks/src/lib/types/ScheduledTaskTypes.ts
@@ -42,9 +42,9 @@ export type ScheduledTaskListRepeatedReturnType = ReturnType<BullClient['getRepe
 export type ScheduledTasksTaskOptions = {
 	repeated: boolean;
 } & (
-	| { delay: number; interval?: never; pattern?: never; customJobOptions?: ScheduledTaskCustomJobOptions }
-	| { delay?: never; interval: number; pattern?: never; customJobOptions?: ScheduledTaskCustomJobOptions }
-	| { delay?: never; interval?: never; pattern: string; customJobOptions?: ScheduledTaskCustomJobOptions }
+	| { delay: number; interval?: never; pattern?: never; timezone?: never; customJobOptions?: ScheduledTaskCustomJobOptions }
+	| { delay?: never; interval: number; pattern?: never; timezone?: never; customJobOptions?: ScheduledTaskCustomJobOptions }
+	| { delay?: never; interval?: never; pattern: string; timezone: string; customJobOptions?: ScheduledTaskCustomJobOptions }
 );
 
 /**


### PR DESCRIPTION
This PR adds timezone support for pattern tasks.

The Changes in this PR would not constitute a breaking change.