### PR TITLE
fix(plugins): fixed name for plugin subcommnad cooldown precondition

### DIFF
--- a/packages/subcommands/src/index.ts
+++ b/packages/subcommands/src/index.ts
@@ -1,5 +1,8 @@
 import type { CooldownOptions } from '@sapphire/framework';
-import { PluginPrecondition as SubcommandCooldown, type SubcommandCooldownPreconditionContext } from './preconditions/PluginSubcommandCooldown';
+import {
+	PluginPrecondition as PluginSubcommandCooldown,
+	type PluginSubcommandCooldownPreconditionContext
+} from './preconditions/PluginSubcommandCooldown';
 
 export * from './lib/Subcommand';
 export * as SubcommandPreconditionResolvers from './lib/precondition-resolvers/subcommandCooldown';
@@ -33,7 +36,7 @@ declare module 'discord.js' {
 
 declare module '@sapphire/framework' {
 	interface Preconditions {
-		SubcommandCooldown: SubcommandPreconditions.SubcommandCooldownContext;
+		PluginSubcommandCooldown: SubcommandPreconditions.PluginSubcommandCooldownContext;
 	}
 }
 
@@ -42,7 +45,7 @@ declare module '@sapphire/framework' {
  * @since 5.1.0
  */
 export const SubcommandPreconditions = {
-	SubcommandCooldown
+	PluginSubcommandCooldown
 };
 
 /**
@@ -51,7 +54,7 @@ export const SubcommandPreconditions = {
  */
 export namespace SubcommandPreconditions {
 	/** The context for the subcommand cooldown precondition */
-	export type SubcommandCooldownContext = SubcommandCooldownPreconditionContext;
+	export type PluginSubcommandCooldownContext = PluginSubcommandCooldownPreconditionContext;
 }
 
 /**

--- a/packages/subcommands/src/lib/precondition-resolvers/subcommandCooldown.ts
+++ b/packages/subcommands/src/lib/precondition-resolvers/subcommandCooldown.ts
@@ -27,7 +27,7 @@ export interface ParseSubcommandConstructorPreConditionsCooldownParameters<
 }
 
 /**
- * Appends the `SubcommandCooldown` precondition when {@link Subcommand.Options.cooldownLimit} and
+ * Appends the `PluginSubcommandCooldown` precondition when {@link Subcommand.Options.cooldownLimit} and
  * {@link Subcommand.Options.cooldownDelay} are both non-zero.
  *
  * @param options The {@link ParseSubcommandConstructorPreConditionsCooldownParameters} for adding this subcommand cooldown precondition
@@ -62,7 +62,7 @@ export function parseSubcommandConstructorPreConditionsCooldown<
 		const filteredUsers = cooldownFilteredUsers ?? subcommandDefaultCooldown?.filteredUsers;
 
 		preconditionContainerArray.append({
-			name: SubcommandCommandPreConditions.SubcommandCooldown,
+			name: SubcommandCommandPreConditions.PluginSubcommandCooldown,
 			context: { scope, limit, delay, filteredUsers, subcommandGroupName, subcommandMethodName }
 		});
 	}

--- a/packages/subcommands/src/lib/types/Enums.ts
+++ b/packages/subcommands/src/lib/types/Enums.ts
@@ -3,7 +3,7 @@
  * @since 2.0.0
  */
 export enum SubcommandCommandPreConditions {
-	SubcommandCooldown = 'SubcommandCooldown'
+	PluginSubcommandCooldown = 'PluginSubcommandCooldown'
 }
 
 /**

--- a/packages/subcommands/src/preconditions/PluginSubcommandCooldown.ts
+++ b/packages/subcommands/src/preconditions/PluginSubcommandCooldown.ts
@@ -15,7 +15,7 @@ import { SubcommandIdentifiers } from '../lib/types/Enums';
  * The context for the subcommand cooldown precondition
  * @since 5.1.0
  */
-export interface SubcommandCooldownPreconditionContext extends CorePreconditions.CooldownContext {
+export interface PluginSubcommandCooldownPreconditionContext extends CorePreconditions.CooldownContext {
 	/** The name of the subcommand */
 	subcommandMethodName: string;
 	/** The name of the subcommand group, if any */
@@ -33,7 +33,7 @@ export class PluginPrecondition extends AllFlowsPrecondition {
 	public override messageRun(
 		message: Message,
 		subcommand: Subcommand,
-		context: SubcommandCooldownPreconditionContext
+		context: PluginSubcommandCooldownPreconditionContext
 	): AllFlowsPrecondition.Result {
 		const cooldownId = this.getIdFromMessage(message, context);
 
@@ -43,7 +43,7 @@ export class PluginPrecondition extends AllFlowsPrecondition {
 	public override chatInputRun(
 		interaction: ChatInputCommandInteraction,
 		subcommand: Subcommand,
-		context: SubcommandCooldownPreconditionContext
+		context: PluginSubcommandCooldownPreconditionContext
 	): AllFlowsPrecondition.Result {
 		const cooldownId = this.getIdFromInteraction(interaction, context);
 
@@ -53,7 +53,7 @@ export class PluginPrecondition extends AllFlowsPrecondition {
 	public override contextMenuRun(
 		interaction: ContextMenuCommandInteraction,
 		subcommand: Command,
-		context: SubcommandCooldownPreconditionContext
+		context: PluginSubcommandCooldownPreconditionContext
 	): AllFlowsPrecondition.Result {
 		const cooldownId = this.getIdFromInteraction(interaction, context);
 
@@ -63,7 +63,7 @@ export class PluginPrecondition extends AllFlowsPrecondition {
 	private sharedRun(
 		authorId: string,
 		subcommand: Subcommand,
-		context: SubcommandCooldownPreconditionContext,
+		context: PluginSubcommandCooldownPreconditionContext,
 		cooldownId: string,
 		commandType: string
 	): AllFlowsPrecondition.Result {
@@ -93,7 +93,7 @@ export class PluginPrecondition extends AllFlowsPrecondition {
 		return this.ok();
 	}
 
-	private getIdFromMessage(message: Message, context: SubcommandCooldownPreconditionContext) {
+	private getIdFromMessage(message: Message, context: PluginSubcommandCooldownPreconditionContext) {
 		const subcommandIdentifier = this.getSubcommandMappingName(context);
 		switch (context.scope) {
 			case BucketScope.Global:
@@ -107,7 +107,7 @@ export class PluginPrecondition extends AllFlowsPrecondition {
 		}
 	}
 
-	private getIdFromInteraction(interaction: CommandInteraction, context: SubcommandCooldownPreconditionContext) {
+	private getIdFromInteraction(interaction: CommandInteraction, context: PluginSubcommandCooldownPreconditionContext) {
 		const subcommandIdentifier = this.getSubcommandMappingName(context);
 		switch (context.scope) {
 			case BucketScope.Global:
@@ -121,11 +121,11 @@ export class PluginPrecondition extends AllFlowsPrecondition {
 		}
 	}
 
-	private getSubcommandMappingName(context: SubcommandCooldownPreconditionContext) {
+	private getSubcommandMappingName(context: PluginSubcommandCooldownPreconditionContext) {
 		return context.subcommandGroupName ? `${context.subcommandGroupName}.${context.subcommandMethodName}` : context.subcommandMethodName;
 	}
 
-	private getManager(subcommand: Subcommand, context: SubcommandCooldownPreconditionContext) {
+	private getManager(subcommand: Subcommand, context: PluginSubcommandCooldownPreconditionContext) {
 		let manager = this.subcommandBuckets.get(subcommand);
 		if (!manager) {
 			manager = new RateLimitManager(context.delay, context.limit);


### PR DESCRIPTION
So technically this would be a breaking change due to the rename in the constant at top level but since it never really worked before I'd say we can push it as a semver:patch.

Reported in https://discord.com/channels/737141877803057244/1190424789043658822