### PR TITLE
fix: fixed container.format not processing variables correctly

### DIFF
--- a/packages/i18next/src/lib/InternationalizationHandler.ts
+++ b/packages/i18next/src/lib/InternationalizationHandler.ts
@@ -4,6 +4,7 @@ import { isFunction, type Awaitable } from '@sapphire/utilities';
 import { Backend, type PathResolvable } from '@skyra/i18next-backend';
 import i18next, {
 	type AppendKeyPrefix,
+	type DefaultNamespace,
 	type InterpolationMap,
 	type Namespace,
 	type ParseKeys,
@@ -16,7 +17,7 @@ import type { PathLike } from 'node:fs';
 import { opendir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { URL, fileURLToPath } from 'node:url';
-import type { $Dictionary, InternationalizationContext, InternationalizationOptions } from './types';
+import type { $Dictionary, $SpecialObject, InternationalizationContext, InternationalizationOptions } from './types';
 
 /**
  * A generalized class for handling `i18next` JSON files and their discovery.
@@ -195,9 +196,9 @@ export class InternationalizationHandler {
 	 */
 	public format<
 		const Key extends ParseKeys<Ns, TOpt, undefined>,
-		const TOpt extends TOptions,
-		Ns extends Namespace,
-		Ret extends TFunctionReturn<Ns, AppendKeyPrefix<Key, undefined>, TOpt>,
+		const TOpt extends TOptions = TOptions,
+		Ns extends Namespace = DefaultNamespace,
+		Ret extends TFunctionReturn<Ns, AppendKeyPrefix<Key, undefined>, TOpt> = TOpt['returnObjects'] extends true ? $SpecialObject : string,
 		const ActualOptions extends TOpt & InterpolationMap<Ret> = TOpt & InterpolationMap<Ret>
 	>(
 		locale: string,
@@ -218,7 +219,7 @@ export class InternationalizationHandler {
 					? language(this.options.defaultMissingKey, { replace: { key } })
 					: '';
 
-		return language<Key, TOpt, Ret, ActualOptions>(key, defaultValue, optionsOrUndefined);
+		return language<Key, TOpt, Ret, ActualOptions>(key, { defaultValue, ...((optionsOrUndefined ?? {}) as TOpt) });
 	}
 
 	/**


### PR DESCRIPTION
@kyranet and I noticed this in Skyra. Why no other Sapphire users reported this as a bug is truly beyond me. 

Despite i18next happily accepting 3 parameters, in actuality, it's supposed to be just 2 with the `defaultValue` being part of an object as the second parameter. I think I didn't write it like this initially because without the `as TOpt` type cast an error is thrown due to a type mismatch with the generic types but that is easily resolved then.

I also added some more function generic type defaults to match that of `resolveKey` and this way it should allow `format` to smartly return a `string` whereas before it would always, as far as types were concerned, return an object.