### PR TITLE
refactor(route)!: change method handling

### DIFF
--- a/packages/api/src/lib/structures/MediaParser.ts
+++ b/packages/api/src/lib/structures/MediaParser.ts
@@ -18,7 +18,7 @@ export abstract class MediaParser<Options extends MediaParser.Options = MediaPar
 	 * Parses the body data from an API request.
 	 * @since 1.3.0
 	 */
-	public abstract run(request: ApiRequest): Awaitable<unknown>;
+	public abstract run(request: MediaParser.Request): Awaitable<unknown>;
 
 	/**
 	 * Checks if a route accepts the media type from this parser.
@@ -34,7 +34,7 @@ export abstract class MediaParser<Options extends MediaParser.Options = MediaPar
 	 * @since 1.3.0
 	 * @param request The request to read the body from.
 	 */
-	protected async readString(request: ApiRequest): Promise<string> {
+	protected async readString(request: MediaParser.Request): Promise<string> {
 		const stream = this.contentStream(request);
 		if (stream === null) return '';
 
@@ -49,7 +49,7 @@ export abstract class MediaParser<Options extends MediaParser.Options = MediaPar
 	 * @since 1.3.0
 	 * @param request The request to read the body from.
 	 */
-	protected async readBuffer(request: ApiRequest): Promise<Buffer> {
+	protected async readBuffer(request: MediaParser.Request): Promise<Buffer> {
 		const stream = this.contentStream(request);
 		if (stream === null) return Buffer.alloc(0);
 
@@ -64,7 +64,7 @@ export abstract class MediaParser<Options extends MediaParser.Options = MediaPar
 	 * @since 1.3.0
 	 * @param request The request to read the body from.
 	 */
-	protected contentStream(request: ApiRequest): ApiRequest | Gunzip | null {
+	protected contentStream(request: MediaParser.Request): MediaParser.Request | Gunzip | null {
 		switch ((request.headers['content-encoding'] ?? 'identity').toLowerCase()) {
 			// RFC 7230 4.2.2:
 			//
@@ -114,4 +114,6 @@ export namespace MediaParser {
 	export type Options = Piece.Options;
 	export type JSON = Piece.JSON;
 	export type LocationJSON = Piece.LocationJSON;
+
+	export type Request = ApiRequest;
 }

--- a/packages/api/src/lib/structures/Middleware.ts
+++ b/packages/api/src/lib/structures/Middleware.ts
@@ -31,7 +31,7 @@ export abstract class Middleware<Options extends Middleware.Options = Middleware
 	 * @param response The server's response.
 	 * @param route The route that matched this request, will be `null` if none matched.
 	 */
-	public abstract run(request: ApiRequest, response: ApiResponse, route: Route | null): Awaitable<unknown>;
+	public abstract run(request: Middleware.Request, response: Middleware.Response, route: Route | null): Awaitable<unknown>;
 }
 
 /**
@@ -53,4 +53,7 @@ export namespace Middleware {
 	export type Options = MiddlewareOptions;
 	export type JSON = Piece.JSON;
 	export type LocationJSON = Piece.LocationJSON;
+
+	export type Request = ApiRequest;
+	export type Response = ApiResponse;
 }

--- a/packages/api/src/lib/structures/MiddlewareStore.ts
+++ b/packages/api/src/lib/structures/MiddlewareStore.ts
@@ -1,8 +1,6 @@
 import { Store } from '@sapphire/pieces';
 import { Middleware } from './Middleware';
 import type { Route } from './Route';
-import type { ApiRequest } from './api/ApiRequest';
-import type { ApiResponse } from './api/ApiResponse';
 
 /**
  * @since 1.0.0
@@ -17,7 +15,7 @@ export class MiddlewareStore extends Store<Middleware, 'middlewares'> {
 		super(Middleware, { name: 'middlewares' });
 	}
 
-	public async run(request: ApiRequest, response: ApiResponse, route: Route | null): Promise<void> {
+	public async run(request: Middleware.Request, response: Middleware.Response, route: Route | null): Promise<void> {
 		for (const middleware of this.sortedMiddlewares) {
 			if (response.writableEnded) return;
 			if (middleware.enabled) await middleware.run(request, response, route);

--- a/packages/api/src/lib/structures/Route.ts
+++ b/packages/api/src/lib/structures/Route.ts
@@ -39,7 +39,7 @@ import type { MimeTypeWithoutParameters } from './http/Server';
  * ```
  *
  * ```bash
- * $ curl -H "Content-Type: application/json" -d '{"hello":"world"}' http://localhost:4000/echo
+ * $ curl -X POST -H "Content-Type: application/json" -d '{"hello":"world"}' http://localhost:4000/echo
  * {"hello":"world"}
  * ```
  */

--- a/packages/api/src/lib/structures/RouteLoaderStrategy.ts
+++ b/packages/api/src/lib/structures/RouteLoaderStrategy.ts
@@ -1,0 +1,22 @@
+import { LoaderStrategy } from '@sapphire/pieces';
+import { Collection } from 'discord.js';
+import type { Route } from './Route';
+import type { RouteStore } from './RouteStore';
+
+export class RouteLoaderStrategy extends LoaderStrategy<Route> {
+	public override onLoad(store: RouteStore, piece: Route): void {
+		for (const method of piece.methods) {
+			store.methods.ensure(method, () => new Collection()).set(piece, piece.router);
+		}
+	}
+
+	public override onUnload(store: RouteStore, piece: Route): void {
+		for (const method of piece.methods) {
+			const methods = store.methods.get(method);
+			if (typeof methods === 'undefined') continue;
+
+			methods.delete(piece);
+			if (methods.size === 0) store.methods.delete(method);
+		}
+	}
+}

--- a/packages/api/src/lib/structures/RouteStore.ts
+++ b/packages/api/src/lib/structures/RouteStore.ts
@@ -1,35 +1,25 @@
 import { Store } from '@sapphire/pieces';
+import { isNullish } from '@sapphire/utilities';
 import { Collection } from 'discord.js';
 import { URLSearchParams } from 'url';
-import type { ApiRequest } from './api/ApiRequest';
-import type { ApiResponse } from './api/ApiResponse';
-import { methodEntries, type Methods } from './http/HttpMethods';
+import type { RouteData } from '../utils/RouteData';
 import { Route } from './Route';
+import { RouteLoaderStrategy } from './RouteLoaderStrategy';
+import type { MethodName } from './http/HttpMethods';
 
 const slash = '/'.charCodeAt(0);
-
-export interface MethodCallback {
-	(request: ApiRequest, response: ApiResponse): unknown;
-}
-
-export interface RouteMatch {
-	route: Route;
-	cb: MethodCallback;
-}
 
 /**
  * @since 1.0.0
  */
 export class RouteStore extends Store<Route, 'routes'> {
-	public readonly table = new Collection<Methods, Collection<Route, MethodCallback>>();
+	public readonly methods = new Collection<MethodName, Collection<Route, RouteData>>();
 
 	public constructor() {
-		super(Route, { name: 'routes' });
-
-		for (const [method] of methodEntries) this.table.set(method, new Collection());
+		super(Route, { name: 'routes', strategy: new RouteLoaderStrategy() });
 	}
 
-	public match(request: ApiRequest): RouteMatch | null {
+	public match(request: Route.Request): Route | null {
 		const { method } = request;
 
 		// If there is no method, we can't match a route so return null
@@ -37,24 +27,24 @@ export class RouteStore extends Store<Route, 'routes'> {
 			return null;
 		}
 
-		// We get all the methods that are tied to the provided method to have a smaller list to filter through
-		const methodTable = this.table.get(method as Methods);
+		// We get all the routes that are tied to the provided method to have a smaller list to filter through
+		const methodTable = this.methods.get(method as MethodName);
 
-		// If there are no methods of the provided type then we won't find any route so we return null
-		if (typeof methodTable === 'undefined') {
+		// If there are no routes of the provided type then we won't find any route so we return null
+		if (isNullish(methodTable)) {
 			return null;
 		}
 
 		const { splits, querystring } = this.parseURL(request.url);
 
-		for (const [route, cb] of methodTable.entries()) {
-			const result = route.router.match(splits);
+		for (const [route, router] of methodTable.entries()) {
+			const result = router.match(splits);
 			if (result === null) continue;
 
 			request.params = result;
 			request.query = Object.fromEntries(new URLSearchParams(querystring).entries());
 
-			return { route, cb };
+			return route;
 		}
 
 		return null;
@@ -63,10 +53,8 @@ export class RouteStore extends Store<Route, 'routes'> {
 	private parseURL(url = '') {
 		const index = url.indexOf('?');
 
-		/* eslint-disable @typescript-eslint/init-declarations */
 		let pathname: string;
 		let querystring: string;
-		/* eslint-enable @typescript-eslint/init-declarations */
 		if (index === -1) {
 			pathname = url;
 			querystring = '';

--- a/packages/api/src/lib/structures/api/CookieStore.ts
+++ b/packages/api/src/lib/structures/api/CookieStore.ts
@@ -25,8 +25,8 @@ export class CookieStore extends Map<string, string> {
 			const index = pair.indexOf('=');
 			if (index === -1) continue;
 
-			const key = decodeURIComponent(pair.substr(0, index).trim());
-			const value = decodeURIComponent(pair.substr(index + 1).trim());
+			const key = decodeURIComponent(pair.slice(0, index).trim());
+			const value = decodeURIComponent(pair.slice(index + 1).trim());
 			this.set(key, value);
 		}
 
@@ -59,7 +59,7 @@ export class CookieStore extends Map<string, string> {
 			set = [set.toString()];
 		}
 
-		set = set.filter((i) => i.substr(0, i.indexOf('=')) !== name);
+		set = set.filter((i) => i.slice(0, i.indexOf('=')) !== name);
 		set.push(entry);
 
 		this.response.setHeader('Set-Cookie', set);

--- a/packages/api/src/lib/structures/http/HttpMethods.ts
+++ b/packages/api/src/lib/structures/http/HttpMethods.ts
@@ -1,41 +1,38 @@
-import { METHODS } from 'node:http';
+export type MethodName = (typeof MethodNames)[number];
 
-export type Methods =
-	| 'ACL'
-	| 'BIND'
-	| 'CHECKOUT'
-	| 'CONNECT'
-	| 'COPY'
-	| 'DELETE'
-	| 'GET'
-	| 'HEAD'
-	| 'LINK'
-	| 'LOCK'
-	| 'M-SEARCH'
-	| 'MERGE'
-	| 'MKACTIVITY'
-	| 'MKCALENDAR'
-	| 'MKCOL'
-	| 'MOVE'
-	| 'NOTIFY'
-	| 'OPTIONS'
-	| 'PATCH'
-	| 'POST'
-	| 'PRI'
-	| 'PROPFIND'
-	| 'PROPPATCH'
-	| 'PURGE'
-	| 'PUT'
-	| 'REBIND'
-	| 'REPORT'
-	| 'SEARCH'
-	| 'SOURCE'
-	| 'SUBSCRIBE'
-	| 'TRACE'
-	| 'UNBIND'
-	| 'UNLINK'
-	| 'UNLOCK'
-	| 'UNSUBSCRIBE';
-
-export const methods = Object.fromEntries(METHODS.map((method) => [method as Methods, Symbol(`HTTP-${method}`)])) as Record<Methods, symbol>;
-export const methodEntries = Object.entries(methods) as readonly [Methods, symbol][];
+export const MethodNames = [
+	'ACL',
+	'BIND',
+	'CHECKOUT',
+	'CONNECT',
+	'COPY',
+	'DELETE',
+	'GET',
+	'HEAD',
+	'LINK',
+	'LOCK',
+	'M-SEARCH',
+	'MERGE',
+	'MKACTIVITY',
+	'MKCALENDAR',
+	'MKCOL',
+	'MOVE',
+	'NOTIFY',
+	'OPTIONS',
+	'PATCH',
+	'POST',
+	'PROPFIND',
+	'PROPPATCH',
+	'PURGE',
+	'PUT',
+	'REBIND',
+	'REPORT',
+	'SEARCH',
+	'SOURCE',
+	'SUBSCRIBE',
+	'TRACE',
+	'UNBIND',
+	'UNLINK',
+	'UNLOCK',
+	'UNSUBSCRIBE'
+] as const;

--- a/packages/api/src/lib/structures/http/Server.ts
+++ b/packages/api/src/lib/structures/http/Server.ts
@@ -4,7 +4,8 @@ import { Server as HttpServer, createServer as httpCreateServer, type ServerOpti
 import type { ListenOptions } from 'node:net';
 import { MediaParserStore } from '../MediaParserStore';
 import { MiddlewareStore } from '../MiddlewareStore';
-import { RouteStore, type RouteMatch } from '../RouteStore';
+import type { Route } from '../Route';
+import { RouteStore } from '../RouteStore';
 import { ApiRequest } from '../api/ApiRequest';
 import { ApiResponse } from '../api/ApiResponse';
 import { Auth, type ServerOptionsAuth } from './Auth';
@@ -253,5 +254,5 @@ export interface MiddlewareErrorContext {
 	 * The route match.
 	 * @since 1.2.0
 	 */
-	match: RouteMatch;
+	match: Route;
 }

--- a/packages/api/src/lib/structures/http/Server.ts
+++ b/packages/api/src/lib/structures/http/Server.ts
@@ -254,5 +254,5 @@ export interface MiddlewareErrorContext {
 	 * The route match.
 	 * @since 1.2.0
 	 */
-	match: Route;
+	route: Route;
 }

--- a/packages/api/src/listeners/PluginServerMatch.ts
+++ b/packages/api/src/listeners/PluginServerMatch.ts
@@ -1,7 +1,5 @@
 import { Listener } from '@sapphire/framework';
-import type { RouteMatch } from '../lib/structures/RouteStore';
-import type { ApiRequest } from '../lib/structures/api/ApiRequest';
-import type { ApiResponse } from '../lib/structures/api/ApiResponse';
+import type { Route } from '../lib/structures/Route';
 import { ServerEvents } from '../lib/structures/http/Server';
 
 export class PluginListener extends Listener {
@@ -9,12 +7,12 @@ export class PluginListener extends Listener {
 		super(context, { emitter: 'server', event: ServerEvents.Match });
 	}
 
-	public override run(request: ApiRequest, response: ApiResponse, match: RouteMatch) {
+	public override run(request: Route.Request, response: Route.Response, route: Route) {
 		this.container.server.emit(
 			response.writableEnded ? ServerEvents.MiddlewareFailure : ServerEvents.MiddlewareSuccess,
 			request,
 			response,
-			match
+			route
 		);
 	}
 }

--- a/packages/api/src/listeners/PluginServerMiddlewareSuccess.ts
+++ b/packages/api/src/listeners/PluginServerMiddlewareSuccess.ts
@@ -7,11 +7,11 @@ export class PluginListener extends Listener {
 		super(context, { emitter: 'server', event: ServerEvents.MiddlewareSuccess });
 	}
 
-	public override async run(request: Route.Request, response: Route.Response, match: Route) {
+	public override async run(request: Route.Request, response: Route.Response, route: Route) {
 		try {
-			await match.run(request, response);
+			await route.run(request, response);
 		} catch (error) {
-			this.container.server.emit(ServerEvents.RouteError, error, { request, response, match });
+			this.container.server.emit(ServerEvents.RouteError, error, { request, response, route });
 		}
 	}
 }

--- a/packages/api/src/listeners/PluginServerMiddlewareSuccess.ts
+++ b/packages/api/src/listeners/PluginServerMiddlewareSuccess.ts
@@ -1,7 +1,5 @@
 import { Listener } from '@sapphire/framework';
-import type { RouteMatch } from '../lib/structures/RouteStore';
-import type { ApiRequest } from '../lib/structures/api/ApiRequest';
-import type { ApiResponse } from '../lib/structures/api/ApiResponse';
+import type { Route } from '../lib/structures/Route';
 import { ServerEvents } from '../lib/structures/http/Server';
 
 export class PluginListener extends Listener {
@@ -9,9 +7,9 @@ export class PluginListener extends Listener {
 		super(context, { emitter: 'server', event: ServerEvents.MiddlewareSuccess });
 	}
 
-	public override async run(request: ApiRequest, response: ApiResponse, match: RouteMatch) {
+	public override async run(request: Route.Request, response: Route.Response, match: Route) {
 		try {
-			await match.cb(request, response);
+			await match.run(request, response);
 		} catch (error) {
 			this.container.server.emit(ServerEvents.RouteError, error, { request, response, match });
 		}

--- a/packages/api/src/listeners/PluginServerRequest.ts
+++ b/packages/api/src/listeners/PluginServerRequest.ts
@@ -9,22 +9,22 @@ export class PluginListener extends Listener {
 	}
 
 	public override async run(request: ApiRequest, response: ApiResponse) {
-		const match = this.container.server.routes.match(request);
+		const route = this.container.server.routes.match(request);
 
 		try {
 			// Middlewares need to be run regardless of the match, specially since browsers do an OPTIONS request first.
-			await this.container.server.middlewares.run(request, response, match?.route ?? null);
+			await this.container.server.middlewares.run(request, response, route);
 		} catch (error) {
-			this.container.server.emit(ServerEvents.MiddlewareError, error, { request, response, match });
+			this.container.server.emit(ServerEvents.MiddlewareError, error, { request, response, match: route });
 
 			// If a middleware errored, it might cause undefined behavior in the routes, so we will return early.
 			return;
 		}
 
-		if (match === null) {
+		if (route === null) {
 			this.container.server.emit(ServerEvents.NoMatch, request, response);
 		} else {
-			this.container.server.emit(ServerEvents.Match, request, response, match);
+			this.container.server.emit(ServerEvents.Match, request, response, route);
 		}
 	}
 }

--- a/packages/api/src/listeners/PluginServerRequest.ts
+++ b/packages/api/src/listeners/PluginServerRequest.ts
@@ -15,7 +15,7 @@ export class PluginListener extends Listener {
 			// Middlewares need to be run regardless of the match, specially since browsers do an OPTIONS request first.
 			await this.container.server.middlewares.run(request, response, route);
 		} catch (error) {
-			this.container.server.emit(ServerEvents.MiddlewareError, error, { request, response, match: route });
+			this.container.server.emit(ServerEvents.MiddlewareError, error, { request, response, route });
 
 			// If a middleware errored, it might cause undefined behavior in the routes, so we will return early.
 			return;

--- a/packages/api/src/mediaParsers/applicationJson.ts
+++ b/packages/api/src/mediaParsers/applicationJson.ts
@@ -1,5 +1,4 @@
 import { MediaParser } from '../lib/structures/MediaParser';
-import type { ApiRequest } from '../lib/structures/api/ApiRequest';
 import { MimeTypes } from '../lib/utils/MimeTypes';
 
 export class PluginMediaParser extends MediaParser {
@@ -7,7 +6,7 @@ export class PluginMediaParser extends MediaParser {
 		super(context, { name: MimeTypes.ApplicationJson });
 	}
 
-	public override async run(request: ApiRequest): Promise<unknown> {
+	public override async run(request: MediaParser.Request): Promise<unknown> {
 		const body = await this.readString(request);
 		return body.length === 0 ? null : JSON.parse(body);
 	}

--- a/packages/api/src/mediaParsers/textPlain.ts
+++ b/packages/api/src/mediaParsers/textPlain.ts
@@ -1,4 +1,3 @@
-import type { ApiRequest } from '../lib/structures/api/ApiRequest';
 import { MediaParser } from '../lib/structures/MediaParser';
 import { MimeTypes } from '../lib/utils/MimeTypes';
 
@@ -7,7 +6,7 @@ export class PluginMediaParser extends MediaParser {
 		super(context, { name: MimeTypes.TextPlain });
 	}
 
-	public override async run(request: ApiRequest): Promise<unknown> {
+	public override async run(request: MediaParser.Request): Promise<unknown> {
 		const body = await this.readString(request);
 		return body.length === 0 ? null : body;
 	}

--- a/packages/api/src/middlewares/auth.ts
+++ b/packages/api/src/middlewares/auth.ts
@@ -1,5 +1,3 @@
-import type { ApiRequest } from '../lib/structures/api/ApiRequest';
-import type { ApiResponse } from '../lib/structures/api/ApiResponse';
 import { Middleware } from '../lib/structures/Middleware';
 
 export class PluginMiddleware extends Middleware {
@@ -13,7 +11,7 @@ export class PluginMiddleware extends Middleware {
 		this.enabled = server.auth !== null;
 	}
 
-	public override run(request: ApiRequest, response: ApiResponse) {
+	public override run(request: Middleware.Request, response: Middleware.Response) {
 		// If there are no cookies, set auth as null:
 		const authorization = response.cookies.get(this.cookieName);
 		if (!authorization) {

--- a/packages/api/src/middlewares/body.ts
+++ b/packages/api/src/middlewares/body.ts
@@ -1,5 +1,3 @@
-import type { ApiRequest } from '../lib/structures/api/ApiRequest';
-import type { ApiResponse } from '../lib/structures/api/ApiResponse';
 import { HttpCodes } from '../lib/structures/http/HttpCodes';
 import type { MediaParserStore } from '../lib/structures/MediaParserStore';
 import { Middleware } from '../lib/structures/Middleware';
@@ -13,7 +11,7 @@ export class PluginMiddleware extends Middleware {
 		this.mediaParsers = this.container.server.mediaParsers;
 	}
 
-	public override async run(request: ApiRequest, response: ApiResponse, route: Route) {
+	public override async run(request: Middleware.Request, response: Middleware.Response, route: Route) {
 		// RFC 1341 4.
 		const contentType = request.headers['content-type'];
 		if (typeof contentType !== 'string') return;

--- a/packages/api/src/middlewares/cookies.ts
+++ b/packages/api/src/middlewares/cookies.ts
@@ -1,6 +1,4 @@
 import { Middleware } from '../lib/structures/Middleware';
-import type { ApiRequest } from '../lib/structures/api/ApiRequest';
-import type { ApiResponse } from '../lib/structures/api/ApiResponse';
 import { CookieStore } from '../lib/structures/api/CookieStore';
 
 export class PluginMiddleware extends Middleware {
@@ -14,7 +12,7 @@ export class PluginMiddleware extends Middleware {
 		this.domainOverwrite = server.auth?.domainOverwrite ?? null;
 	}
 
-	public override run(request: ApiRequest, response: ApiResponse) {
+	public override run(request: Middleware.Request, response: Middleware.Response) {
 		response.cookies = new CookieStore(request, response, this.production, this.domainOverwrite);
 	}
 }

--- a/packages/api/src/routes/_load.ts
+++ b/packages/api/src/routes/_load.ts
@@ -1,6 +1,6 @@
 import { container } from '@sapphire/pieces';
-import { PluginRoute as PluginOAuthCallback } from './oauth/callback';
-import { PluginRoute as PluginOAuthLogout } from './oauth/logout';
+import { PluginRoute as PluginOAuthCallback } from './oauth/callback.post';
+import { PluginRoute as PluginOAuthLogout } from './oauth/logout.post';
 
 export function loadRoutes() {
 	const store = 'routes' as const;

--- a/packages/api/src/routes/oauth/callback.post.ts
+++ b/packages/api/src/routes/oauth/callback.post.ts
@@ -2,23 +2,20 @@ import { OAuth2Routes, type RESTPostOAuth2AccessTokenResult, type RESTPostOAuth2
 import { stringify } from 'querystring';
 import { fetch } from 'undici';
 import { Route } from '../../lib/structures/Route';
-import type { ApiRequest } from '../../lib/structures/api/ApiRequest';
-import type { ApiResponse } from '../../lib/structures/api/ApiResponse';
 import { HttpCodes } from '../../lib/structures/http/HttpCodes';
-import { methods } from '../../lib/structures/http/HttpMethods';
 
 export class PluginRoute extends Route {
 	private readonly redirectUri: string | undefined;
 
 	public constructor(context: Route.LoaderContext) {
-		super(context, { route: 'oauth/callback' });
+		super(context, { route: 'oauth/callback', methods: ['POST'] });
 
 		const { server } = this.container;
 		this.enabled = server.auth !== null;
 		this.redirectUri = server.auth?.redirect;
 	}
 
-	public override async [methods.POST](request: ApiRequest, response: ApiResponse) {
+	public override async run(request: Route.Request, response: Route.Response) {
 		const body = request.body as OAuth2BodyData;
 		if (typeof body?.code !== 'string') {
 			return response.badRequest();

--- a/packages/api/src/routes/oauth/logout.post.ts
+++ b/packages/api/src/routes/oauth/logout.post.ts
@@ -1,22 +1,17 @@
+import { sleep } from '@sapphire/utilities';
 import { OAuth2Routes } from 'discord.js';
 import { stringify } from 'querystring';
 import { fetch } from 'undici';
-import { promisify } from 'util';
 import { Route } from '../../lib/structures/Route';
-import type { ApiRequest } from '../../lib/structures/api/ApiRequest';
-import type { ApiResponse } from '../../lib/structures/api/ApiResponse';
 import { HttpCodes } from '../../lib/structures/http/HttpCodes';
-import { methods } from '../../lib/structures/http/HttpMethods';
-
-const sleep = promisify(setTimeout);
 
 export class PluginRoute extends Route {
 	public constructor(context: Route.LoaderContext) {
-		super(context, { route: 'oauth/logout' });
+		super(context, { route: 'oauth/logout', methods: ['POST'] });
 		this.enabled = this.container.server.auth !== null;
 	}
 
-	public override async [methods.POST](request: ApiRequest, response: ApiResponse) {
+	public override async run(request: Route.Request, response: Route.Response) {
 		if (!request.auth) return response.status(HttpCodes.Unauthorized).json({ error: 'Unauthorized.' });
 
 		const result = await this.revoke(request.auth.token);
@@ -50,7 +45,7 @@ export class PluginRoute extends Route {
 		return response.status(HttpCodes.InternalServerError).json({ error: 'Unexpected error from server.' });
 	}
 
-	private success(response: ApiResponse) {
+	private success(response: Route.Response) {
 		// Sending an empty cookie with "expires" set to 1970-01-01 makes the browser instantly remove the cookie.
 		response.cookies.remove(this.container.server.auth!.cookie);
 		return response.json({ success: true });


### PR DESCRIPTION
- 🚀 Added support for specifying a route's supported methods in the options
- 🚀 Added support for specifying a route's method in the file name
- ⌨️ Added `MediaParser.Request` and `MediaParser.Response` type aliases
- ⌨️ Added `Middleware.Request` and `Middleware.Response` type aliases
- 🏠 Hardened the `onLoad` and `onUnload` hooks from the `Route` class
- 🔥 **BREAKING CHANGE:** The headers middleware now uses the supported HTTP methods from the route or the store instead of sending all supported methods
- 🔥 **BREAKING CHANGE:** Changed the method handling in the `Route` class to not be keyed by the method name, sending all requests to the `run` method. This allows for more flexibility in the route handling
- 🔥 **BREAKING CHANGE:** Writing the name of a file as `<name>.<method>.ts` will now set `<method>` as a method for the route

👀 
![Code_Q58K8JkR3H](https://github.com/sapphiredev/plugins/assets/24852502/5ee0aa5a-138e-4929-808e-4c79e1b2536d)