### PR TITLE
docs(readme): remove duplication in Scheduled Tasks README

### DIFF
--- a/packages/scheduled-tasks/README.md
+++ b/packages/scheduled-tasks/README.md
@@ -195,10 +195,6 @@ declare module '@sapphire/plugin-scheduled-tasks' {
 }
 ```
 
-##### Using Interval tasks
-
-Pattern & Interval tasks are loaded automatically.
-
 ## Buy us some doughnuts
 
 Sapphire Community is and always will be open source, even if we don't get donations. That being said, we know there are amazing people who may still want to donate just to show their appreciation. Thank you very much in advance!


### PR DESCRIPTION
I have removed the duplication in the README file of the scheduled tasks plugin.