### PR TITLE
feat(router): add FS group syntax

### DIFF
--- a/packages/api/src/lib/structures/Route.ts
+++ b/packages/api/src/lib/structures/Route.ts
@@ -68,10 +68,10 @@ export abstract class Route<Options extends Route.Options = Route.Options> exten
 		super(context, options);
 
 		const api = this.container.server.options;
-		const path = ([] as string[]).concat(
-			RouterRoot.normalize(api.prefix),
-			RouterRoot.normalize(options.route ?? (this.location.virtual ? this.name : this.location.directories.concat(this.name).join('/')))
-		);
+		const path = [
+			...RouterRoot.normalize(api.prefix),
+			...RouterRoot.normalize(options.route ?? RouterRoot.makeRoutePathForPiece(this.location.directories, this.name))
+		];
 
 		const methods = new Set(options.methods);
 		const implied = RouterRoot.extractMethod(path);

--- a/packages/api/src/lib/structures/router/RouterRoot.ts
+++ b/packages/api/src/lib/structures/router/RouterRoot.ts
@@ -40,15 +40,15 @@ export class RouterRoot extends RouterBranch {
 
 	public static makeRoutePathForPiece(directories: readonly string[], name: string): string {
 		const parts: string[] = [];
-		for (let directory of directories) {
-			directory = directory.trim();
+		for (const directory of directories) {
+			const trimmed = directory.trim();
 
 			// If empty, skip:
-			if (isNullishOrEmpty(directory)) continue;
+			if (isNullishOrEmpty(trimmed)) continue;
 			// If it's a group, skip:
-			if (directory.startsWith('(') && directory.endsWith(')')) continue;
+			if (trimmed.startsWith('(') && trimmed.endsWith(')')) continue;
 
-			parts.push(directory);
+			parts.push(trimmed);
 		}
 
 		parts.push(name);

--- a/packages/api/src/lib/structures/router/RouterRoot.ts
+++ b/packages/api/src/lib/structures/router/RouterRoot.ts
@@ -51,7 +51,7 @@ export class RouterRoot extends RouterBranch {
 			parts.push(trimmed);
 		}
 
-		parts.push(name);
+		parts.push(name.trim());
 		return parts.join('/');
 	}
 

--- a/packages/api/src/lib/structures/router/RouterRoot.ts
+++ b/packages/api/src/lib/structures/router/RouterRoot.ts
@@ -38,6 +38,23 @@ export class RouterRoot extends RouterBranch {
 		return '';
 	}
 
+	public static makeRoutePathForPiece(directories: readonly string[], name: string): string {
+		const parts: string[] = [];
+		for (let directory of directories) {
+			directory = directory.trim();
+
+			// If empty, skip:
+			if (isNullishOrEmpty(directory)) continue;
+			// If it's a group, skip:
+			if (directory.startsWith('(') && directory.endsWith(')')) continue;
+
+			parts.push(directory);
+		}
+
+		parts.push(name);
+		return parts.join('/');
+	}
+
 	public static normalize(path: string | null | undefined): string[] {
 		const parts = [] as string[];
 		if (isNullishOrEmpty(path)) return parts;


### PR DESCRIPTION
This allows for grouping routes together in the router:

```ts
-| routes/
---| information.get.ts
---| (legal)/
-----| license.get.ts
-----| privacy.get.ts
```

This will produce the following routes:

- `GET /information`
- `GET /license`
- `GET /privacy`

The `legal` group is ignored for purposes of the
route URL path.
