### PR TITLE
docs(SubcommandMappings): fix messageRun example

### DIFF
--- a/packages/subcommands/src/lib/types/SubcommandMappings.ts
+++ b/packages/subcommands/src/lib/types/SubcommandMappings.ts
@@ -64,7 +64,7 @@ export interface SubcommandMappingMethod
 	 *
 	 * @example
 	 * ```typescript
-	 * messageRun(message: Message) {
+	 * runAdminConfig(message: Message) {
 	 *    return message.reply(`<@${message.author.id}> has been granted admin`);
 	 * }
 	 * ```


### PR DESCRIPTION
This fixes the example provided for `messageRun` in the `packages/subcommands/src/lib/types/SubcommandMappings.ts` file.