### PR TITLE
fix(api): revert removing index import for api plugin register file

### DIFF
--- a/packages/api/src/register.ts
+++ b/packages/api/src/register.ts
@@ -1,3 +1,5 @@
+import './index';
+
 import { Plugin, postInitialization, preLogin, SapphireClient } from '@sapphire/framework';
 import type { ClientOptions } from 'discord.js';
 import { loadListeners, loadMiddlewares, loadRoutes, Server } from './index';


### PR DESCRIPTION
Somehow the index import with the merged types for the api plugin ended up decoupled from the plugin register file; without it, the client constructor will not take any configuration settings for the api plugin and the container will not have the server object. This PR restores the import to the same state as the other plugins in the repo.

The current workaround is to import both the index and register file to get the ambient declarations to be detected by TypeScript again which seems unintentional.

```ts
// One of these is not like the others...
import '@sapphire/plugin-api/register';
import '@sapphire/plugin-api';
import '@sapphire/plugin-logger/register';
import '@sapphire/plugin-i18next/register';
```
