### PR TITLE
fix(ScheduledTaskHandler): Throw task error on run if present

### DIFF
--- a/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
+++ b/packages/scheduled-tasks/src/lib/ScheduledTaskHandler.ts
@@ -221,10 +221,12 @@ export class ScheduledTaskHandler {
 			return duration;
 		});
 
-		result.inspectErr((error) => container.client.emit(ScheduledTaskEvents.ScheduledTaskError, error, piece, payload));
-
-		const value = result.unwrapOrElse((error) => {
-			throw error;
+		const value = result.match({
+			ok: (value) => value,
+			err(error) {
+				container.client.emit(ScheduledTaskEvents.ScheduledTaskError, error, piece, payload);
+				throw error;
+			}
 		});
 
 		container.client.emit(ScheduledTaskEvents.ScheduledTaskFinished, piece, value, payload);


### PR DESCRIPTION
Required for working backoff strategy;
Probably not the best way to do it, but it works